### PR TITLE
Rename groupId to org.sonarsource.api.plugin

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-group=org.sonarsource.sonar-plugin-api
+group=org.sonarsource.api.plugin
 version=9.5
 description=Plugin API for SonarQube, SonarCloud and SonarLint
 projectTitle=sonar-plugin-api


### PR DESCRIPTION
@jacek-poreda-sonarsource I realized that group ids should follow java's packaging convention.
https://maven.apache.org/guides/mini/guide-naming-conventions.html
What do you think about using this one?