### PR TITLE
PLUGINAPI-12 Add support for context-specific sections descriptions

### DIFF
--- a/sonar-plugin-api/src/main/java/org/sonar/api/server/rule/Context.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/server/rule/Context.java
@@ -1,0 +1,49 @@
+/*
+ * Sonar Plugin API
+ * Copyright (C) 2009-2022 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.api.server.rule;
+
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Describes the context in which a {@link RuleDescriptionSection} is defined. Contexts can be for example frameworks - each rule may have
+ * slightly different description section for each framework (context).
+ * @since 9.7
+ */
+public class Context {
+
+  private final String key;
+  private final String displayName;
+
+  public Context(String key, String displayName) {
+    requireNonNull(key, "key must be provided");
+    requireNonNull(displayName, "displayName must be provided");
+    this.key = key;
+    this.displayName = displayName;
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  public String getDisplayName() {
+    return displayName;
+  }
+}

--- a/sonar-plugin-api/src/main/java/org/sonar/api/server/rule/ContextAwareRuleDescriptionSection.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/server/rule/ContextAwareRuleDescriptionSection.java
@@ -1,0 +1,40 @@
+/*
+ * Sonar Plugin API
+ * Copyright (C) 2009-2022 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.api.server.rule;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+class ContextAwareRuleDescriptionSection extends DefaultRuleDescriptionSection {
+
+  private final Context context;
+
+  ContextAwareRuleDescriptionSection(String key, Context context, String htmlContent) {
+    super(key, htmlContent);
+    requireNonNull(context, "context must be provided");
+    this.context = context;
+  }
+
+  @Override
+  public Optional<Context> getContext() {
+    return Optional.of(context);
+  }
+}

--- a/sonar-plugin-api/src/main/java/org/sonar/api/server/rule/RuleDescriptionSection.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/server/rule/RuleDescriptionSection.java
@@ -19,6 +19,8 @@
  */
 package org.sonar.api.server.rule;
 
+import java.util.Optional;
+
 /**
  * Represents a sub-section of a rule description (What's the risk, Assess the risk, etc.)
  *
@@ -28,6 +30,7 @@ public interface RuleDescriptionSection {
 
   /**
    * This class is a placeholder for the supported rule description section key constants.
+   *
    * @since 9.5
    */
   class RuleDescriptionSectionKeys {
@@ -45,6 +48,13 @@ public interface RuleDescriptionSection {
   String getKey();
 
   String getHtmlContent();
+
+  /**
+   * @since 9.7
+   */
+  default Optional<Context> getContext() {
+    return Optional.empty();
+  }
 
   static RuleDescriptionSectionBuilder builder() {
     return new RuleDescriptionSectionBuilder();

--- a/sonar-plugin-api/src/main/java/org/sonar/api/server/rule/RuleDescriptionSectionBuilder.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/server/rule/RuleDescriptionSectionBuilder.java
@@ -21,13 +21,19 @@ package org.sonar.api.server.rule;
 
 import java.io.IOException;
 import java.net.URL;
+import javax.annotation.Nullable;
 import org.apache.commons.io.IOUtils;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+/**
+ * This builder allows to build the right implementation of {@link RuleDescriptionSection}, depending on the provided arguments
+ * @since 9.5
+ */
 public final class RuleDescriptionSectionBuilder {
   private String sectionKey;
   private String htmlContent;
+  private Context context;
 
   /**
    * Identifier of the section, must be unique across sections of a given rule
@@ -58,7 +64,20 @@ public final class RuleDescriptionSectionBuilder {
     return this;
   }
 
-  public RuleDescriptionSection build() {
-    return new DefaultRuleDescriptionSection(sectionKey, htmlContent);
+  /**
+   * For context specific descriptions, the context key, must be unique across a given section of a rule.
+   * @since 9.7
+   */
+  public RuleDescriptionSectionBuilder context(@Nullable Context context) {
+    this.context = context;
+    return this;
   }
+
+  public RuleDescriptionSection build() {
+    if (context == null) {
+      return new DefaultRuleDescriptionSection(sectionKey, htmlContent);
+    }
+    return new ContextAwareRuleDescriptionSection(sectionKey, context, htmlContent);
+  }
+
 }

--- a/sonar-plugin-api/src/main/java/org/sonar/api/server/rule/RulesDefinition.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/server/rule/RulesDefinition.java
@@ -406,6 +406,9 @@ public interface RulesDefinition {
      * For backward compatibility, one of the old method {@link #setHtmlDescription(String)} or {@link #setHtmlDescription(URL)} still
      * need to be called on top of that one.
      *
+     * Each section must have a different section key when they are non-contextual.
+     * As soon as one section is contextual for a section key, all sections with that key must be contextual. The pair "section key, context key" pair must still be unique.
+     *
      * @since 9.5
      */
     public abstract NewRule addDescriptionSection(RuleDescriptionSection ruleDescriptionSection);

--- a/sonar-plugin-api/src/test/java/org/sonar/api/batch/bootstrap/ProjectDefinitionTest.java
+++ b/sonar-plugin-api/src/test/java/org/sonar/api/batch/bootstrap/ProjectDefinitionTest.java
@@ -23,7 +23,6 @@ import java.util.HashMap;
 import java.util.Map;
 import org.junit.Test;
 import org.sonar.api.CoreProperties;
-import org.sonar.api.server.rule.RuleDescriptionSection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -34,7 +33,6 @@ public class ProjectDefinitionTest {
     ProjectDefinition def = ProjectDefinition.create();
     def.setKey("mykey");
     assertThat(def.getKey()).isEqualTo("mykey");
-    String s = RuleDescriptionSection.RuleDescriptionSectionKeys.RESOURCES_SECTION_KEY;
   }
 
   @Test

--- a/sonar-plugin-api/src/test/java/org/sonar/api/server/rule/ContextAwareRuleDescriptionSectionTest.java
+++ b/sonar-plugin-api/src/test/java/org/sonar/api/server/rule/ContextAwareRuleDescriptionSectionTest.java
@@ -1,0 +1,49 @@
+/*
+ * Sonar Plugin API
+ * Copyright (C) 2009-2022 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.api.server.rule;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+public class ContextAwareRuleDescriptionSectionTest {
+
+  private static final String SECTION_KEY = "key";
+  private static final String SECTION_HTML_CONTENT = "description";
+
+  @Test
+  public void constructor_instantiateFieldsCorrectly() {
+    Context context = new Context("ctxKey", "ctxDisplayName");
+    RuleDescriptionSection section = new ContextAwareRuleDescriptionSection(SECTION_KEY, context, SECTION_HTML_CONTENT);
+
+    assertThat(section.getKey()).isEqualTo(SECTION_KEY);
+    assertThat(section.getHtmlContent()).isEqualTo(SECTION_HTML_CONTENT);
+    assertThat(section.getContext()).contains(context);
+  }
+
+  @Test
+  public void constructor_whenGivenNullContext_shouldFail() {
+    assertThatNullPointerException()
+      .isThrownBy(() -> new ContextAwareRuleDescriptionSection(SECTION_KEY, null, SECTION_HTML_CONTENT))
+      .withMessage("context must be provided");
+  }
+
+}

--- a/sonar-plugin-api/src/test/java/org/sonar/api/server/rule/ContextTest.java
+++ b/sonar-plugin-api/src/test/java/org/sonar/api/server/rule/ContextTest.java
@@ -1,0 +1,51 @@
+/*
+ * Sonar Plugin API
+ * Copyright (C) 2009-2022 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.api.server.rule;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+public class ContextTest {
+
+  private static final String TEST_CONTEXT_KEY = "CONTEXT_KEY";
+  private static final String TEST_CONTEXT_DISPLAY_NAME = "CTX Display name";
+
+  @Test
+  public void constructor_assign_to_relevant_fields() {
+    Context context = new Context(TEST_CONTEXT_KEY, TEST_CONTEXT_DISPLAY_NAME);
+    assertThat(context.getKey()).isEqualTo(TEST_CONTEXT_KEY);
+    assertThat(context.getDisplayName()).isEqualTo(TEST_CONTEXT_DISPLAY_NAME);
+  }
+
+  @Test
+  public void constructor_throws_if_context_key_missing() {
+    assertThatNullPointerException().isThrownBy(() -> new Context(null, TEST_CONTEXT_DISPLAY_NAME))
+      .withMessage("key must be provided");
+  }
+
+  @Test
+  public void constructor_throws_if_context_display_name_missing() {
+    assertThatNullPointerException().isThrownBy(() -> new Context(TEST_CONTEXT_KEY, null))
+      .withMessage("displayName must be provided");
+  }
+
+}

--- a/sonar-plugin-api/src/test/java/org/sonar/api/server/rule/RuleDescriptionSectionBuilderTest.java
+++ b/sonar-plugin-api/src/test/java/org/sonar/api/server/rule/RuleDescriptionSectionBuilderTest.java
@@ -21,6 +21,7 @@ package org.sonar.api.server.rule;
 
 import java.net.URL;
 import java.util.Objects;
+import java.util.Optional;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -31,11 +32,34 @@ public class RuleDescriptionSectionBuilderTest {
   private static final String TEST_HTML_DESCRIPTION = "test HTML description";
   private static final String TEST_SECTION_KEY = "Test";
   private static final String RULE_DESCRIPTION_FILE = "RuleDescriptionSectionBuilderTest.html";
+
+  private static final String TEST_CONTEXT_DISPLAY_NAME = "TEST_CONTEXT_DISPLAY_NAME";
+  private static final String TEST_CONTEXT_KEY = "CONTEXT_KEY";
+  private static final Context TEST_CONTEXT = new Context(TEST_CONTEXT_KEY, TEST_CONTEXT_DISPLAY_NAME);
+
   private final URL RULE_DESCRIPTION_FILE_URL = Objects.requireNonNull(getClass().getResource(RULE_DESCRIPTION_FILE));
+
+  @Test
+  public void build_sets_all_fields() {
+    RuleDescriptionSection descriptionSection = new RuleDescriptionSectionBuilder()
+      .sectionKey(TEST_SECTION_KEY)
+      .htmlContent(TEST_HTML_DESCRIPTION)
+      .context(TEST_CONTEXT)
+      .build();
+
+    assertThat(descriptionSection).isInstanceOf(ContextAwareRuleDescriptionSection.class);
+    assertThat(descriptionSection.getKey()).isEqualTo(TEST_SECTION_KEY);
+    assertThat(descriptionSection.getHtmlContent()).isEqualTo(TEST_HTML_DESCRIPTION);
+    Optional<Context> context = descriptionSection.getContext();
+    assertThat(context).isPresent();
+    assertThat(context.get().getKey()).isEqualTo(TEST_CONTEXT_KEY);
+    assertThat(context.get().getDisplayName()).isEqualTo(TEST_CONTEXT_DISPLAY_NAME);
+  }
 
   @Test
   public void build_withSectionKeyAndHtmlDescription() {
     RuleDescriptionSection descriptionSection = new RuleDescriptionSectionBuilder().sectionKey(TEST_SECTION_KEY).htmlContent(TEST_HTML_DESCRIPTION).build();
+    assertThat(descriptionSection).isInstanceOf(RuleDescriptionSection.class);
     assertThat(descriptionSection.getKey()).isEqualTo(TEST_SECTION_KEY);
     assertThat(descriptionSection.getHtmlContent()).isEqualTo(TEST_HTML_DESCRIPTION);
   }
@@ -43,6 +67,7 @@ public class RuleDescriptionSectionBuilderTest {
   @Test
   public void build_withSectionKeyAndHtmlResource_shouldLoadContentFromResource() {
     RuleDescriptionSection descriptionSection = new RuleDescriptionSectionBuilder().sectionKey(TEST_SECTION_KEY).htmlClasspathResourceUrl(RULE_DESCRIPTION_FILE_URL).build();
+    assertThat(descriptionSection).isInstanceOf(RuleDescriptionSection.class);
     assertThat(descriptionSection.getKey()).isEqualTo(TEST_SECTION_KEY);
     assertThat(descriptionSection.getHtmlContent()).isEqualTo(contentOf(RULE_DESCRIPTION_FILE_URL));
   }


### PR DESCRIPTION
In the context of [MMF-2804](https://jira.sonarsource.com/browse/MMF-2804) we need to provide the (optional) support for many contextualised descriptions for a single section key.

For instance, the section "how to fix" will have different contents corresponding to Spring, Servlet API and FrameworkXYZ.

We tried to not break anything in the current API to avoid backward incompatibility issues.

