### PR TITLE
Enforce building with JDK 11 at Gradle level

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 Java API to develop plugins for SonarQube, SonarCloud and SonarLint.
 This component was extracted out of SonarQube, and is released independently since v9.5.
 
+The API is built with JDK 11.
+
 ## Developing plugins
 See documentation [here](https://docs.sonarqube.org/latest/extend/developing-plugin/) about how to use the `sonar-plugin-api` to develop plugins.
 

--- a/build.gradle
+++ b/build.gradle
@@ -84,6 +84,12 @@ subprojects {
   apply plugin: 'java'
   apply plugin: 'maven-publish'
 
+  java {
+    toolchain {
+      languageVersion = JavaLanguageVersion.of(11)
+    }
+  }
+
   jacoco {
     toolVersion = "0.8.7"
   }


### PR DESCRIPTION
This will bring more consistency between dev machines and the CI. Also makes it official that JDK 11 is the target.