### PR TITLE
PLUGINAPI-22 Empty content for rule description section should not be…

### DIFF
--- a/sonar-plugin-api/src/main/java/org/sonar/api/server/rule/Context.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/server/rule/Context.java
@@ -19,13 +19,13 @@
  */
 package org.sonar.api.server.rule;
 
-
-import static java.util.Objects.requireNonNull;
+import static org.apache.commons.lang.StringUtils.isEmpty;
 import static org.sonar.api.server.rule.StringPatternValidator.validatorWithCommonPatternForKeys;
 
 /**
  * Describes the context in which a {@link RuleDescriptionSection} is defined. Contexts can be for example frameworks - each rule may have
  * slightly different description section for each framework (context).
+ *
  * @since 9.7
  */
 public class Context {
@@ -36,13 +36,12 @@ public class Context {
   private final String displayName;
 
   /**
-   *
-   * @param key the context Key, must follow the pattern defined in {@link StringPatternValidator#COMMON_PATTERN_FOR_KEYS}
+   * @param key         the context Key, must follow the pattern defined in {@link StringPatternValidator#COMMON_PATTERN_FOR_KEYS}
    * @param displayName
    */
   public Context(String key, String displayName) {
-    requireNonNull(key, "key must be provided");
-    requireNonNull(displayName, "displayName must be provided");
+    failIfEmpty(key, "key must be provided and can't be empty");
+    failIfEmpty(displayName, "displayName must be provided and can't be empty");
     CONTEXT_KEY_VALIDATOR.validate(key);
     this.key = key;
     this.displayName = displayName;
@@ -54,5 +53,11 @@ public class Context {
 
   public String getDisplayName() {
     return displayName;
+  }
+
+  private static void failIfEmpty(String str, String msg) {
+    if (isEmpty(str)) {
+      throw new IllegalArgumentException(msg);
+    }
   }
 }

--- a/sonar-plugin-api/src/main/java/org/sonar/api/server/rule/DefaultRuleDescriptionSection.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/server/rule/DefaultRuleDescriptionSection.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.api.server.rule;
 
-import static java.util.Objects.requireNonNull;
+import static org.apache.commons.lang.StringUtils.isEmpty;
 
 class DefaultRuleDescriptionSection implements RuleDescriptionSection {
 
@@ -27,8 +27,8 @@ class DefaultRuleDescriptionSection implements RuleDescriptionSection {
   private final String htmlContent;
 
   DefaultRuleDescriptionSection(String key, String htmlContent) {
-    requireNonNull(key, "The section key must be provided");
-    requireNonNull(htmlContent, "The html content of the section must be provided");
+    failIfEmpty(key, "The section key must be provided and can't be empty");
+    failIfEmpty(htmlContent, "The html content of the section must be provided and can't be empty");
     this.key = key;
     this.htmlContent = htmlContent;
   }
@@ -43,4 +43,9 @@ class DefaultRuleDescriptionSection implements RuleDescriptionSection {
     return htmlContent;
   }
 
+  private static void failIfEmpty(String str, String msg) {
+    if (isEmpty(str)) {
+      throw new IllegalArgumentException(msg);
+    }
+  }
 }

--- a/sonar-plugin-api/src/test/java/org/sonar/api/server/rule/ContextTest.java
+++ b/sonar-plugin-api/src/test/java/org/sonar/api/server/rule/ContextTest.java
@@ -39,8 +39,8 @@ public class ContextTest {
 
   @Test
   public void constructor_throws_if_context_key_missing() {
-    assertThatNullPointerException().isThrownBy(() -> new Context(null, TEST_CONTEXT_DISPLAY_NAME))
-      .withMessage("key must be provided");
+    assertThatIllegalArgumentException().isThrownBy(() -> new Context(null, TEST_CONTEXT_DISPLAY_NAME))
+      .withMessage("key must be provided and can't be empty");
   }
 
   @Test
@@ -50,8 +50,20 @@ public class ContextTest {
 
   @Test
   public void constructor_throws_if_context_display_name_missing() {
-    assertThatNullPointerException().isThrownBy(() -> new Context(TEST_CONTEXT_KEY, null))
-      .withMessage("displayName must be provided");
+    assertThatIllegalArgumentException().isThrownBy(() -> new Context(TEST_CONTEXT_KEY, null))
+      .withMessage("displayName must be provided and can't be empty");
+  }
+
+  @Test
+  public void constructor_throws_if_context_key_empty() {
+    assertThatIllegalArgumentException().isThrownBy(() -> new Context("", TEST_CONTEXT_DISPLAY_NAME))
+      .withMessage("key must be provided and can't be empty");
+  }
+
+  @Test
+  public void constructor_throws_if_context_display_name_empty() {
+    assertThatIllegalArgumentException().isThrownBy(() -> new Context(TEST_CONTEXT_KEY, ""))
+      .withMessage("displayName must be provided and can't be empty");
   }
 
 }

--- a/sonar-plugin-api/src/test/java/org/sonar/api/server/rule/DefaultRuleDescriptionSectionTest.java
+++ b/sonar-plugin-api/src/test/java/org/sonar/api/server/rule/DefaultRuleDescriptionSectionTest.java
@@ -22,6 +22,7 @@ package org.sonar.api.server.rule;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
 public class DefaultRuleDescriptionSectionTest {
@@ -39,16 +40,29 @@ public class DefaultRuleDescriptionSectionTest {
 
   @Test
   public void constructor_whenGivenNullKey_shouldFail() {
-    assertThatNullPointerException()
+    assertThatIllegalArgumentException()
       .isThrownBy(() -> new DefaultRuleDescriptionSection(null, SECTION_HTML_CONTENT))
-      .withMessage("The section key must be provided");
+      .withMessage("The section key must be provided and can't be empty");
   }
 
   @Test
   public void constructor_whenGivenNullHtmlContent_shouldFail() {
-    assertThatNullPointerException()
+    assertThatIllegalArgumentException()
       .isThrownBy(() -> new DefaultRuleDescriptionSection(SECTION_KEY, null))
-      .withMessage("The html content of the section must be provided");
+      .withMessage("The html content of the section must be provided and can't be empty");
   }
 
+  @Test
+  public void constructor_whenGivenEmptyKey_shouldFail() {
+    assertThatIllegalArgumentException()
+      .isThrownBy(() -> new DefaultRuleDescriptionSection("", SECTION_HTML_CONTENT))
+      .withMessage("The section key must be provided and can't be empty");
+  }
+
+  @Test
+  public void constructor_whenGivenEmptyHtmlContent_shouldFail() {
+    assertThatIllegalArgumentException()
+      .isThrownBy(() -> new DefaultRuleDescriptionSection(SECTION_KEY, ""))
+      .withMessage("The html content of the section must be provided and can't be empty");
+  }
 }


### PR DESCRIPTION
I've tested that:
- SQ Enterprise fails to start up with the security plugins before the bug fix
- SQ Enterprise works fine with its current plugins