### PR TITLE
MMF-2811 support code highlighting in issue messages

### DIFF
--- a/plugin-api/src/main/java/org/sonar/api/batch/fs/TextRange.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/fs/TextRange.java
@@ -45,7 +45,7 @@ public interface TextRange {
 
   /**
    * Test if the current range has some common area with another range.
-   * Exemple: say the two ranges are on same line. Range with offsets [1,3] overlaps range with offsets [2,4] but not
+   * Example: say the two ranges are on same line. Range with offsets [1,3] overlaps range with offsets [2,4] but not
    * range with offset [3,5]
    */
   boolean overlap(TextRange another);

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/issue/MessageFormatting.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/issue/MessageFormatting.java
@@ -19,40 +19,28 @@
  */
 package org.sonar.api.batch.sensor.issue;
 
-import java.util.List;
-import javax.annotation.CheckForNull;
-import org.sonar.api.batch.fs.InputComponent;
-import org.sonar.api.batch.fs.TextRange;
-
 /**
- * Represents an issue location.
- *
- * @since 5.2
+ * Represents the data of the formatted part of the text in the issue message
+ * @since 9.13
  */
-public interface IssueLocation {
+public interface MessageFormatting {
+
+  enum Type {
+    CODE
+  }
 
   /**
-   * The {@link InputComponent} this location belongs to.
+   * The index of the first character in the string that will be formatted
    */
-  InputComponent inputComponent();
+  int start();
 
   /**
-   * Range of the issue. Null for global issues and issues on directories. Can also be null
-   * for files (issue global to the file).
+   * The index of the last character in the string that will be formatted
    */
-  @CheckForNull
-  TextRange textRange();
+  int end();
 
   /**
-   * Message of the issue.
+   * Type of the text that will be formatted
    */
-  @CheckForNull
-  String message();
-
-  /**
-   * @return list of text ranges in the message that can be highlighted when
-   * displaying the message according to specified type
-   */
-  List<MessageFormatting> messageFormattings();
-
+  Type type();
 }

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/issue/NewIssueLocation.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/issue/NewIssueLocation.java
@@ -19,6 +19,7 @@
  */
 package org.sonar.api.batch.sensor.issue;
 
+import java.util.List;
 import org.sonar.api.batch.fs.InputComponent;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.TextRange;
@@ -41,7 +42,7 @@ public interface NewIssueLocation {
   NewIssueLocation on(InputComponent component);
 
   /**
-   * Position in the file. Only applicable when {@link #on(InputComponent)} has been called with an InputFile. 
+   * Position in the file. Only applicable when {@link #on(InputComponent)} has been called with an InputFile.
    * See {@link InputFile#newRange(org.sonar.api.batch.fs.TextPointer, org.sonar.api.batch.fs.TextPointer)}
    */
   NewIssueLocation at(TextRange location);
@@ -52,5 +53,28 @@ public interface NewIssueLocation {
    * Formats like Markdown or HTML are not supported. Size must not be greater than {@link #MESSAGE_MAX_SIZE} characters.
    */
   NewIssueLocation message(String message);
+
+  /**
+   * Optional, message that can be formatted on the frontend.<br>
+   *
+   * Formats like Markdown or HTML are not supported. Size must not be greater than {@link #MESSAGE_MAX_SIZE} characters.<br>
+   *
+   * throws {@link java.lang.IllegalArgumentException} if any of the {@link org.sonar.api.batch.sensor.issue.NewMessageFormatting}
+   * instances passed in the {@code newMessageFormatting} is that:<br>
+   * - start is lesser than 0<br>
+   * - end is lesser than start<br>
+   * - end is greater than the size of {@code message}
+   *
+   * @since 9.13
+   */
+  NewIssueLocation message(String message, List<NewMessageFormatting> newMessageFormatting);
+
+  /**
+   * Creates new instance of NewMessageFormatting
+   * @return builder for NewMessageFormatting
+   *
+   * @since 9.13
+   */
+  NewMessageFormatting newMessageFormatting();
 
 }

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/issue/NewMessageFormatting.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/issue/NewMessageFormatting.java
@@ -19,40 +19,28 @@
  */
 package org.sonar.api.batch.sensor.issue;
 
-import java.util.List;
-import javax.annotation.CheckForNull;
-import org.sonar.api.batch.fs.InputComponent;
-import org.sonar.api.batch.fs.TextRange;
-
 /**
- * Represents an issue location.
- *
- * @since 5.2
+ * Builder to create new MessageFormatting.
+ * Should not be implemented by client.
+ * @since 9.13
  */
-public interface IssueLocation {
+public interface NewMessageFormatting {
 
   /**
-   * The {@link InputComponent} this location belongs to.
+   * @param index The index of the first character in the string that will be formatted (inclusive)
+   * @return builder object
    */
-  InputComponent inputComponent();
+  NewMessageFormatting start(int index);
 
   /**
-   * Range of the issue. Null for global issues and issues on directories. Can also be null
-   * for files (issue global to the file).
+   * @param index The index at which formatting will stop (exclusive)
+   * @return builder object
    */
-  @CheckForNull
-  TextRange textRange();
+  NewMessageFormatting end(int index);
 
   /**
-   * Message of the issue.
+   * @param type Type of the text that will be formatted
+   * @return builder object
    */
-  @CheckForNull
-  String message();
-
-  /**
-   * @return list of text ranges in the message that can be highlighted when
-   * displaying the message according to specified type
-   */
-  List<MessageFormatting> messageFormattings();
-
+  NewMessageFormatting type(MessageFormatting.Type type);
 }


### PR DESCRIPTION
### Context
In SonarQube team we are working on the [MMF-2811](https://sonarsource.atlassian.net/browse/MMF-2811). This MMF is about highlight the code snippets in the issue messages (and issue location messages). 
The main problem to solve in this MMF is how analyzers would pass this information (which parts of the messages should be higlighted/treated on the frontend as a code) to SonarQube (and possibly in the future to SonarLint and/or SonarCloud).

### Solution
This solution aims to achieve it by adding a new field in the IssueLocation which will contain text range(s) to highlight. To make the solution more future-proof and robust we would also add a type (in example _code_ type) for each of the text ranges.

### Pros & cons
There are some pros and cons to this solution. One of the advantage is that it is backward compatible (as this field is totally optional). With this plan we also don't need to stick to any formatting syntax in the issue message (it is syntax agnostic). And also this solution provide easy way to extend it in the future (to add new types, not only _code_) without much impact on the products (SQ, SC, SL).

From the plugin-api user perspective this solution might be a less usable then other solutions involving syntax formatting that we have considered. 

This PR is not ready to be merged. The goal of this draft is to ask for a review of the high-level solution from Plugin API guild.