### PR TITLE
Replace spring plugin dependency management by Gradle version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,6 @@ plugins {
   id 'com.github.hierynomus.license' version '0.16.1'
   id 'com.github.johnrengelman.shadow' version '7.1.2' apply false
   id 'com.jfrog.artifactory' version '4.28.1'
-  id 'io.spring.dependency-management' version '1.0.11.RELEASE'
   id 'org.sonarqube' version '3.3'
 }
 
@@ -78,7 +77,6 @@ sonarqube {
 subprojects {
   apply plugin: 'com.github.hierynomus.license'
   apply plugin: 'com.jfrog.artifactory'
-  apply plugin: 'io.spring.dependency-management'
   apply plugin: 'jacoco'
   apply plugin: 'java'
   apply plugin: 'maven-publish'
@@ -134,42 +132,6 @@ subprojects {
   }
 
   rootProject.tasks["sonarqube"].dependsOn jacocoTestReport
-
-  dependencyManagement {
-    dependencies {
-      // bundled plugin list -- keep it alphabetically ordered
-      dependency 'commons-io:commons-io:2.11.0'
-      dependency 'commons-lang:commons-lang:2.6'
-      dependency 'com.google.code.findbugs:jsr305:3.0.2'
-      dependency 'com.google.code.gson:gson:2.9.0'
-      dependency('com.google.guava:guava:31.1-jre') {
-        exclude 'com.google.errorprone:error_prone_annotations'
-        exclude 'com.google.guava:listenablefuture'
-        exclude 'com.google.j2objc:j2objc-annotations'
-        exclude 'org.checkerframework:checker-qual'
-        exclude 'org.codehaus.mojo:animal-sniffer-annotations'
-      }
-      dependency 'com.tngtech.java:junit-dataprovider:1.13.1'
-      dependencySet(group: 'ch.qos.logback', version: '1.2.9') {
-        entry 'logback-access'
-        entry 'logback-classic'
-        entry 'logback-core'
-      }
-      dependency 'javax.servlet:javax.servlet-api:3.1.0'
-      dependency 'junit:junit:4.13.2'
-      dependency 'org.assertj:assertj-core:3.22.0'
-      dependency 'org.junit.jupiter:junit-jupiter-api:5.8.2'
-      dependency('org.mockito:mockito-core:4.4.0') {
-        exclude 'org.hamcrest:hamcrest-core'
-      }
-      dependencySet(group: 'org.slf4j', version: '1.7.30') {
-        entry 'jcl-over-slf4j'
-        entry 'jul-to-slf4j'
-        entry 'log4j-over-slf4j'
-        entry 'slf4j-api'
-      }
-    }
-  }
 
   apply plugin: 'signing'
 

--- a/check-api/build.gradle
+++ b/check-api/build.gradle
@@ -1,3 +1,3 @@
 dependencies {
-  compileOnly 'com.google.code.findbugs:jsr305'
+  compileOnly libs.jsr305
 }

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -2,25 +2,25 @@ apply plugin: 'com.github.johnrengelman.shadow'
 
 dependencies {
   // please keep the list grouped by configuration and ordered by name
-  implementation 'commons-io:commons-io'
-  implementation 'commons-lang:commons-lang'
-  implementation 'com.google.code.gson:gson'
+  implementation libs.commons.io
+  implementation libs.commons.lang
+  implementation libs.gson
 
   // shaded, but not relocated
   implementation project(':check-api')
 
-  compileOnly 'ch.qos.logback:logback-classic'
-  compileOnly 'com.google.code.findbugs:jsr305'
-  compileOnly 'javax.servlet:javax.servlet-api'
-  compileOnly 'junit:junit'
+  compileOnly libs.logback.classic
+  compileOnly libs.jsr305
+  compileOnly libs.servlet.api
+  compileOnly libs.junit4
   // Used by LogTesterJUnit5
-  compileOnly 'org.junit.jupiter:junit-jupiter-api'
-  compileOnly 'org.slf4j:slf4j-api'
+  compileOnly libs.junit5
+  compileOnly libs.slf4j
 
-  testImplementation 'com.google.guava:guava'
-  testImplementation 'com.tngtech.java:junit-dataprovider'
-  testImplementation 'org.assertj:assertj-core'
-  testImplementation 'org.mockito:mockito-core'
+  testImplementation libs.guava
+  testImplementation libs.junit.dataprovider
+  testImplementation libs.assertj
+  testImplementation libs.mockito
 }
 
 configurations {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,23 @@
 rootProject.name='sonar-plugin-api'
 include 'plugin-api'
 include 'check-api'
+
+dependencyResolutionManagement {
+  versionCatalogs {
+    libs {
+      library('commons-io', 'commons-io:commons-io:2.11.0')
+      library('commons-lang', 'commons-lang:commons-lang:2.6')
+      library('guava', 'com.google.guava:guava:31.1-jre')
+      library('gson', 'com.google.code.gson:gson:2.9.0')
+      library('jsr305', 'com.google.code.findbugs:jsr305:3.0.2')
+      library('servlet-api', 'javax.servlet:javax.servlet-api:3.1.0')
+      library('junit4', 'junit:junit:4.13.2')
+      library('junit5', 'org.junit.jupiter:junit-jupiter-api:5.8.2')
+      library('slf4j', 'org.slf4j:slf4j-api:1.7.30')
+      library('logback-classic', 'ch.qos.logback:logback-classic:1.2.9')
+      library('assertj', 'org.assertj:assertj-core:3.22.0')
+      library('mockito', 'org.mockito:mockito-core:4.4.0')
+      library('junit-dataprovider', 'com.tngtech.java:junit-dataprovider:1.13.1')
+    }
+  }
+}


### PR DESCRIPTION
This is an attempt to remove garbage from the pom.xml (all the dependency management stuff is useless).