### PR TITLE
Add font extension to static resource patterns

### DIFF
--- a/plugin-api/src/main/java/org/sonar/api/web/ServletFilter.java
+++ b/plugin-api/src/main/java/org/sonar/api/web/ServletFilter.java
@@ -129,7 +129,7 @@ public abstract class ServletFilter implements Filter {
     public static class Builder {
       private static final String WILDCARD_CHAR = "*";
       private static final Collection<String> STATIC_RESOURCES = unmodifiableList(asList(
-        "*.css", "*.css.map", "*.ico", "*.png", "*.jpg", "*.jpeg", "*.gif", "*.svg", "*.js", "*.js.map", "*.pdf", "/json/*",
+        "*.css", "*.css.map", "*.ico", "*.png", "*.jpg", "*.jpeg", "*.gif", "*.svg", "*.js", "*.js.map", "*.pdf", "/json/*", "*.woff2",
         "/static/*", "/robots.txt", "/favicon.ico", "/apple-touch-icon*", "/mstile*"));
 
       private final Set<String> inclusions = new LinkedHashSet<>();

--- a/plugin-api/src/test/java/org/sonar/api/web/ServletFilterTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/web/ServletFilterTest.java
@@ -223,6 +223,7 @@ public class ServletFilterTest {
       "*.js",
       "*.js.map",
       "*.pdf",
+      "*.woff2",
       "/json/*",
       "/static/*",
       "/robots.txt",


### PR DESCRIPTION
I need to provide fonts as static assets (see https://github.com/SonarSource/sonar-enterprise/pull/7982) It seems we're managing the exclusion list here for SQ. I'm not sure it's the best solution.