### PR TITLE
PLUGINAPI-36 Document default log level with LogTester

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,4 @@
 * Utility classes used to test logs have been moved to a separate artifact `org.sonarsource.api.plugin:sonar-plugin-api-test-fixtures` and moved to a new package:
   *  `org.sonar.api.utils.log.LogTester` &rarr; `org.sonar.api.testfixtures.log.LogTester`
   *  `org.sonar.api.utils.log.LogTesterJUnit5` &rarr; `org.sonar.api.testfixtures.log.LogTesterJUnit5`
+* **Breaking change for tests**: the default log level when using `LogTester` is now `INFO`. This is consistent with the default behavior of Sonar products. If you want to assert `DEBUG` or `TRACE` logs in your tests, you should first change the log level by using for example `logTester.setLevel(Level.DEBUG)`.

--- a/test-fixtures/src/main/java/org/sonar/api/testfixtures/log/LogTester.java
+++ b/test-fixtures/src/main/java/org/sonar/api/testfixtures/log/LogTester.java
@@ -24,10 +24,8 @@ import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
 /**
- * <b>For tests only</b>
- * <br>
- * This JUnit rule allows to configure and access logs in tests. By default
- * trace level is enabled.
+ * This JUnit rule allows to configure and access logs in tests. By default,
+ * INFO level is enabled.
  * <br>
  * Warning - not compatible with parallel execution of tests in the same JVM fork.
  * <br>

--- a/test-fixtures/src/main/java/org/sonar/api/testfixtures/log/LogTesterJUnit5.java
+++ b/test-fixtures/src/main/java/org/sonar/api/testfixtures/log/LogTesterJUnit5.java
@@ -24,10 +24,8 @@ import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
- * <b>For tests only</b>
- * <br>
- * This JUnit 5 extension allows to configure and access logs in tests. By default
- * trace level is enabled.
+ * This JUnit 5 extension allows to configure and access logs in tests. By default,
+ * INFO level is enabled.
  * <br>
  * Warning - not compatible with parallel execution of tests in the same JVM fork.
  * <br>


### PR DESCRIPTION
Based on feedback from @jeremy-davis-sonarsource 

Seems an attempt to change the level to INFO was made in this [commit](https://github.com/SonarSource/sonarqube/commit/21f78c3276b8df5855b1d1111f541f1037dc90b4) a long time ago, but apparently it was not working properly (or we had a regression at some point), since tests could assert DEBUG logs without changing the level.

Now the situation should be cleaner: only INFO logs are collected by LogTester by default (and `isDebugEnabled()` should return `false`). Tests that intentionally want to assert DEBUG or TRACE logs should change the level first.