### PR TITLE
Improve LogTester

### DIFF
--- a/test-fixtures/src/main/java/org/sonar/api/testfixtures/log/AbstractLogTester.java
+++ b/test-fixtures/src/main/java/org/sonar/api/testfixtures/log/AbstractLogTester.java
@@ -49,17 +49,21 @@ class AbstractLogTester<G extends AbstractLogTester<G>> {
 
   private final ConcurrentListAppender<ILoggingEvent> listAppender = new ConcurrentListAppender<>();
 
+  protected AbstractLogTester() {
+    setLevel(Level.INFO);
+  }
+
   protected void before() {
     getRootLogger().addAppender(listAppender);
     listAppender.start();
-    setLevel(LoggerLevel.INFO);
   }
 
   protected void after() {
     listAppender.stop();
     listAppender.list.clear();
     getRootLogger().detachAppender(listAppender);
-    setLevel(LoggerLevel.INFO);
+    // Reset the level for following-up test suites
+    setLevel(Level.INFO);
   }
 
   LoggerLevel getLevel() {
@@ -73,7 +77,7 @@ class AbstractLogTester<G extends AbstractLogTester<G>> {
 
   /**
    * Change log level.
-   * By default INFO logs are enabled when LogTester is started.
+   * By default, INFO logs are enabled when LogTester is started.
    */
   public G setLevel(Level level) {
     getRootLogger().setLevel(ch.qos.logback.classic.Level.fromLocationAwareLoggerInteger(level.toInt()));

--- a/test-fixtures/src/main/java/org/sonar/api/testfixtures/log/AbstractLogTester.java
+++ b/test-fixtures/src/main/java/org/sonar/api/testfixtures/log/AbstractLogTester.java
@@ -131,7 +131,6 @@ class AbstractLogTester<G extends AbstractLogTester<G>> {
       .collect(Collectors.toList());
   }
 
-
   /**
    * Logs with arguments in chronological order (item at index 0 is the oldest one) for
    * a given level
@@ -152,7 +151,7 @@ class AbstractLogTester<G extends AbstractLogTester<G>> {
   }
 
   private static LogAndArguments convert(LoggingEvent e) {
-    return new LogAndArguments(e.getFormattedMessage(), e.getMessage(), e.getArgumentArray());
+    return new LogAndArguments(e.getFormattedMessage(), e.getMessage(), e.getThrowableProxy(), e.getArgumentArray());
   }
 
   public G clear() {

--- a/test-fixtures/src/main/java/org/sonar/api/testfixtures/log/AbstractLogTester.java
+++ b/test-fixtures/src/main/java/org/sonar/api/testfixtures/log/AbstractLogTester.java
@@ -21,7 +21,6 @@ package org.sonar.api.testfixtures.log;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
-import ch.qos.logback.core.read.ListAppender;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -48,7 +47,7 @@ class AbstractLogTester<G extends AbstractLogTester<G>> {
     Level.ERROR, LoggerLevel.ERROR
   );
 
-  private final ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+  private final ConcurrentListAppender<ILoggingEvent> listAppender = new ConcurrentListAppender<>();
 
   protected void before() {
     getRootLogger().addAppender(listAppender);

--- a/test-fixtures/src/main/java/org/sonar/api/testfixtures/log/ConcurrentListAppender.java
+++ b/test-fixtures/src/main/java/org/sonar/api/testfixtures/log/ConcurrentListAppender.java
@@ -1,0 +1,32 @@
+/*
+ * Sonar Plugin API
+ * Copyright (C) 2009-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.api.testfixtures.log;
+
+import ch.qos.logback.core.AppenderBase;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+public class ConcurrentListAppender<E> extends AppenderBase<E> {
+  public final Queue<E> list = new ConcurrentLinkedQueue<E>();
+
+  protected void append(E e) {
+    list.add(e);
+  }
+}

--- a/test-fixtures/src/main/java/org/sonar/api/testfixtures/log/LogAndArguments.java
+++ b/test-fixtures/src/main/java/org/sonar/api/testfixtures/log/LogAndArguments.java
@@ -19,37 +19,29 @@
  */
 package org.sonar.api.testfixtures.log;
 
+import ch.qos.logback.classic.spi.IThrowableProxy;
+import ch.qos.logback.classic.spi.ThrowableProxy;
 import java.util.Arrays;
 import java.util.Optional;
+import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
 public final class LogAndArguments {
   private final String rawMsg;
+  private final Throwable throwable;
   private final Object[] args;
   private final String msg;
 
-  LogAndArguments(String msg, String rawMsg) {
+  LogAndArguments(String msg, String rawMsg, @Nullable IThrowableProxy t, Object... args) {
     this.rawMsg = rawMsg;
     this.msg = msg;
-    this.args = null;
-  }
-
-  LogAndArguments(String msg, String rawMsg, @Nullable Object arg1) {
-    this.rawMsg = rawMsg;
-    this.args = new Object[] {arg1};
-    this.msg = msg;
-  }
-
-  LogAndArguments(String msg, String rawMsg, @Nullable Object arg1, @Nullable Object arg2) {
-    this.rawMsg = rawMsg;
-    this.msg = msg;
-    this.args = new Object[] {arg1, arg2};
-  }
-
-  LogAndArguments(String msg, String rawMsg, Object... args) {
-    this.rawMsg = rawMsg;
-    this.msg = msg;
+    this.throwable = t instanceof ThrowableProxy ? ((ThrowableProxy) t).getThrowable() : null;
     this.args = args;
+  }
+
+  @CheckForNull
+  public Throwable getThrowable() {
+    return throwable;
   }
 
   public String getRawMsg() {
@@ -66,10 +58,12 @@ public final class LogAndArguments {
 
   @Override
   public String toString() {
+    String throwableStr = throwable != null ? (throwable.getClass().getName() + ": " + throwable.getMessage()) : null;
     return "LogAndArguments{" +
       "rawMsg='" + rawMsg + '\'' +
       ", args=" + Arrays.toString(args) +
       ", msg='" + msg + '\'' +
+      ", throwable='" + throwableStr + '\'' +
       '}';
   }
 }

--- a/test-fixtures/src/test/java/org/sonar/api/testfixtures/log/LogAndArgumentsTest.java
+++ b/test-fixtures/src/test/java/org/sonar/api/testfixtures/log/LogAndArgumentsTest.java
@@ -1,0 +1,41 @@
+/*
+ * Sonar Plugin API
+ * Copyright (C) 2009-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.api.testfixtures.log;
+
+import ch.qos.logback.classic.spi.ThrowableProxy;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LogAndArgumentsTest {
+  @Test
+  public void toString_displays_null_throwable() {
+    LogAndArguments logAndArguments = new LogAndArguments("msg", "raw", null, "arg1");
+    assertThat(logAndArguments).hasToString("LogAndArguments{rawMsg='raw', args=[arg1], msg='msg', throwable='null'}");
+  }
+
+  @Test
+  public void toString_includes_all_fields() {
+    Throwable t = new IllegalStateException("tmsg");
+    ThrowableProxy proxy = new ThrowableProxy(t);
+    LogAndArguments logAndArguments = new LogAndArguments("msg", "raw", proxy, "arg1");
+    assertThat(logAndArguments).hasToString("LogAndArguments{rawMsg='raw', args=[arg1], msg='msg', throwable='java.lang.IllegalStateException: tmsg'}");
+  }
+}

--- a/test-fixtures/src/test/java/org/sonar/api/testfixtures/log/LogTesterJUnit5Test.java
+++ b/test-fixtures/src/test/java/org/sonar/api/testfixtures/log/LogTesterJUnit5Test.java
@@ -33,6 +33,7 @@ public class LogTesterJUnit5Test {
   @Test
   public void info_level_by_default() throws Throwable {
     // when LogTester is used, then info logs are enabled by default
+    assertThat(underTest.getLevel()).isEqualTo(LoggerLevel.INFO);
     underTest.beforeEach(null);
     assertThat(underTest.getLevel()).isEqualTo(LoggerLevel.INFO);
 

--- a/test-fixtures/src/test/java/org/sonar/api/testfixtures/log/LogTesterTest.java
+++ b/test-fixtures/src/test/java/org/sonar/api/testfixtures/log/LogTesterTest.java
@@ -51,6 +51,17 @@ public class LogTesterTest {
   }
 
   @Test
+  public void should_change_default_level_before_test() {
+    // Change default level to DEBUG instead of INFO by default
+    LogTester underTest = new LogTester().setLevel(Level.DEBUG);
+    // First test
+    underTest.before();
+    assertThat(underTest.getLevel()).isEqualTo(LoggerLevel.DEBUG);
+    // changing level during a test
+    underTest.setLevel(LoggerLevel.ERROR);
+  }
+
+  @Test
   public void change_log_level() {
     // change level
     underTest.setLevel(Level.DEBUG);


### PR DESCRIPTION
Small problems found when adapting SonarQube to use the new version of the plugin API, with the refactored `logTester`.