### PR TITLE
PLUGINAPI-72 Deprecate 'status','resolution' in favor of 'issueStatus'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 10.5
+
+* Introduce `org.sonar.api.issue.IssueStatus` to simplify `status` and `resolution` on issues.
+* Deprecate `org.sonar.api.ce.measure.Issue.status()` and `org.sonar.api.ce.measure.Issue.resolution()`. Use `org.sonar.api.ce.measure.Issue.issueStatus()` method instead.
+* Deprecate `org.sonar.api.issue.Issue.status()` and `org.sonar.api.issue.Issue.resolution()`. No replacement.
+* Deprecate `STATUS_OPEN`, `STATUS_CONFIRMED`, `STATUS_REOPENED`, `STATUS_RESOLVED`, `STATUS_CLOSED`,
+  `RESOLUTION_FIXED`, `RESOLUTION_FALSE_POSITIVE`, `RESOLUTION_REMOVED`, `RESOLUTION_WONT_FIX`, use `org.sonar.api.issue.IssueStatus` enum instead
+* Deprecate `RESOLUTION_SAFE`, `RESOLUTION_ACKNOWLEDGED`, `STATUS_TO_REVIEW`, `STATUS_REVIEWED`. No replacement.
+
 ## 10.4
 
 * Add new metrics `org.sonar.api.measures.CoreMetrics.NEW_ACCEPTED_ISSUES` and `org.sonar.api.measures.CoreMetrics.HIGH_IMPACT_ACCEPTED_ISSUES`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 * Deprecate `STATUS_OPEN`, `STATUS_CONFIRMED`, `STATUS_REOPENED`, `STATUS_RESOLVED`, `STATUS_CLOSED`,
   `RESOLUTION_FIXED`, `RESOLUTION_FALSE_POSITIVE`, `RESOLUTION_REMOVED`, `RESOLUTION_WONT_FIX`, use `org.sonar.api.issue.IssueStatus` enum instead
 * Deprecate `RESOLUTION_SAFE`, `RESOLUTION_ACKNOWLEDGED`, `STATUS_TO_REVIEW`, `STATUS_REVIEWED`. No replacement.
+* Deprecate `org.sonar.api.measures.CoreMetrics.REOPENED_ISSUES`, `org.sonar.api.measures.CoreMetrics.OPEN_ISSUES`. Use `org.sonar.api.measures.CoreMetrics.VIOLATIONS` instead.
+* Deprecate `org.sonar.api.measures.CoreMetrics.CONFIRMED_ISSUES`. No replacement.
 
 ## 10.4
 

--- a/plugin-api/src/main/java/org/sonar/api/ce/measure/Issue.java
+++ b/plugin-api/src/main/java/org/sonar/api/ce/measure/Issue.java
@@ -21,6 +21,7 @@ package org.sonar.api.ce.measure;
 
 import java.util.Map;
 import javax.annotation.CheckForNull;
+import org.sonar.api.issue.IssueStatus;
 import org.sonar.api.issue.impact.Severity;
 import org.sonar.api.issue.impact.SoftwareQuality;
 import org.sonar.api.rule.RuleKey;
@@ -40,14 +41,26 @@ public interface Issue {
 
   /**
    * Available list of status can be found in {@link org.sonar.api.issue.Issue#STATUSES}
+   *
+   * @deprecated since 10.4 in favor of {@link Issue#issueStatus()}
    */
+  @Deprecated(since = "10.4")
   String status();
 
   /**
    * Available list of resolutions can be found in {@link org.sonar.api.issue.Issue#RESOLUTIONS}
+   *
+   * @deprecated since 10.4 in favor of {@link Issue#issueStatus()}
    */
   @CheckForNull
+  @Deprecated(since = "10.4")
   String resolution();
+
+  /**
+   * @since 10.4
+   * Available list of status can be found in {@link IssueStatus#values()}
+   */
+  IssueStatus issueStatus();
 
   /**
    * See constants in {@link org.sonar.api.rule.Severity}.

--- a/plugin-api/src/main/java/org/sonar/api/issue/Issue.java
+++ b/plugin-api/src/main/java/org/sonar/api/issue/Issue.java
@@ -46,69 +46,114 @@ public interface Issue extends Serializable {
 
   /**
    * Default status when creating an issue.
+   *
+   * @deprecated since 10.4 in favor of {@link IssueStatus}
    */
+  @Deprecated(since = "10.4")
   String STATUS_OPEN = "OPEN";
+  /**
+   * @deprecated since 10.4 in favor of {@link IssueStatus}
+   */
+  @Deprecated(since = "10.4")
   String STATUS_CONFIRMED = "CONFIRMED";
+  /**
+   * @deprecated since 10.4 in favor of {@link IssueStatus}
+   */
+  @Deprecated(since = "10.4")
   String STATUS_REOPENED = "REOPENED";
+  /**
+   * @deprecated since 10.4 in favor of {@link IssueStatus}
+   */
+  @Deprecated(since = "10.4")
   String STATUS_RESOLVED = "RESOLVED";
+  /**
+   * @deprecated since 10.4 in favor of {@link IssueStatus}
+   */
   String STATUS_CLOSED = "CLOSED";
-
+  /**
+   * @deprecated since 10.4 in favor of {@link IssueStatus}
+   */
+  @Deprecated(since = "10.4")
   String RESOLUTION_FIXED = "FIXED";
 
   /**
    * Resolution when issue is flagged as false positive.
    */
+  /**
+   * @deprecated since 10.4 in favor of {@link IssueStatus}
+   */
+  @Deprecated(since = "10.4")
   String RESOLUTION_FALSE_POSITIVE = "FALSE-POSITIVE";
 
   /**
    * Resolution when rule has been uninstalled or disabled in the Quality profile.
-    */
+   * @deprecated since 10.4 in favor of {@link IssueStatus}
+   */
+  @Deprecated(since = "10.4")
   String RESOLUTION_REMOVED = "REMOVED";
 
   /**
    * Issue is irrelevant in the context and was muted by user.
+   * @deprecated since 10.4 in favor of {@link IssueStatus}
    * @since 5.1
    */
+  @Deprecated(since = "10.4")
   String RESOLUTION_WONT_FIX = "WONTFIX";
 
   /**
    * Security Hotspot has been reviewed and resolved as safe.
+   * @deprecated since 10.4 as Security Hotspot are deprecated.
    * @since 8.1
    */
+  @Deprecated(since = "10.4")
   String RESOLUTION_SAFE = "SAFE";
 
   /**
    * Security Hotspot has been reviewed and acknowledged that it poses a risk.
+   * @deprecated since 10.4 as Security Hotspot are deprecated.
    * @since 9.4
    */
+  @Deprecated(since = "10.4")
   String RESOLUTION_ACKNOWLEDGED = "ACKNOWLEDGED";
 
+  /**
+   * @deprecated since 10.4 in favor of {@link IssueStatus}
+   */
+  @Deprecated(since = "10.4")
   List<String> RESOLUTIONS = List.of(RESOLUTION_FALSE_POSITIVE, RESOLUTION_WONT_FIX, RESOLUTION_FIXED,
     RESOLUTION_REMOVED);
 
+  /**
+   * @deprecated since 10.4 as Security Hotspot are deprecated
+   */
+  @Deprecated(since = "10.4")
   List<String> SECURITY_HOTSPOT_RESOLUTIONS = List.of(RESOLUTION_FIXED, RESOLUTION_SAFE, RESOLUTION_ACKNOWLEDGED);
 
   /**
-   * @since 7.8
+   * @deprecated since 10.4 as Security Hotspot are deprecated
    */
+  @Deprecated(since = "10.4")
   String STATUS_TO_REVIEW = "TO_REVIEW";
 
   /**
    * @deprecated since 8.1, status has been mapped as `TO_REVIEW`
    */
-  @Deprecated
+  @Deprecated(since = "8.1")
   String STATUS_IN_REVIEW = "IN_REVIEW";
 
   /**
-   * @since 7.8
+   * @deprecated since 10.4 as Security Hotspot are deprecated
    */
+  @Deprecated(since = "10.4")
   String STATUS_REVIEWED = "REVIEWED";
 
   /**
    * Return all available statuses
    *
    * @since 4.4
+   * @deprecated since 10.4 in favor of {@link IssueStatus}
    */
+  @Deprecated(since = "10.4")
   List<String> STATUSES = List.of(STATUS_OPEN, STATUS_CONFIRMED, STATUS_REOPENED, STATUS_RESOLVED, STATUS_CLOSED,
     STATUS_TO_REVIEW, STATUS_REVIEWED);
 
@@ -161,13 +206,17 @@ public interface Issue extends Serializable {
 
   /**
    * See constant values in {@link Issue}.
+   * @deprecated since 10.4 in favor of {@link IssueStatus}
    */
+  @Deprecated(since = "10.4")
   String status();
 
   /**
    * The type of resolution, or null if the issue is not resolved. See constant values in {@link Issue}.
+   * @deprecated since 10.4 in favor of {@link IssueStatus}
    */
   @CheckForNull
+  @Deprecated(since = "10.4")
   String resolution();
 
   /**
@@ -212,6 +261,7 @@ public interface Issue extends Serializable {
 
   /**
    * During a scan return if the current issue is a new one.
+   *
    * @return always false on server side
    * @since 4.0
    */
@@ -219,6 +269,7 @@ public interface Issue extends Serializable {
 
   /**
    * During a scan returns true if the issue is copied from another branch.
+   *
    * @since 6.6
    */
   boolean isCopied();

--- a/plugin-api/src/main/java/org/sonar/api/issue/IssueStatus.java
+++ b/plugin-api/src/main/java/org/sonar/api/issue/IssueStatus.java
@@ -1,0 +1,86 @@
+/*
+ * Sonar Plugin API
+ * Copyright (C) 2009-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.api.issue;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @since 10.4
+ */
+public enum IssueStatus {
+
+
+  OPEN,
+
+  @Deprecated(since = "10.4")
+  /**
+   * @deprecated use {@link IssueStatus#ACCEPTED} instead
+   */
+  CONFIRMED,
+  FALSE_POSITIVE,
+  ACCEPTED,
+  FIXED;
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(IssueStatus.class);
+
+  @CheckForNull
+  public static IssueStatus of(@Nullable String status, @Nullable String resolution) {
+
+    //null status is not supposed to happen, but since it is nullable in products, we want the mapping to be resilient.
+    if (status == null) {
+      LOGGER.warn("Missing status, falling back to {}", IssueStatus.OPEN);
+      return IssueStatus.OPEN;
+    }
+
+    switch (status) {
+      case Issue.STATUS_OPEN:
+      case Issue.STATUS_REOPENED:
+        return IssueStatus.OPEN;
+      case Issue.STATUS_CONFIRMED:
+        return IssueStatus.CONFIRMED;
+      case Issue.STATUS_CLOSED:
+        return IssueStatus.FIXED;
+      // Security hotspot should not return issue status as they are deprecated.
+      case Issue.STATUS_REVIEWED:
+      case Issue.STATUS_TO_REVIEW:
+        return null;
+      default:
+    }
+    if (Issue.STATUS_RESOLVED.equals(status) && resolution != null) {
+      switch (resolution) {
+        case Issue.RESOLUTION_FALSE_POSITIVE:
+          return IssueStatus.FALSE_POSITIVE;
+        case Issue.RESOLUTION_WONT_FIX:
+          return IssueStatus.ACCEPTED;
+        case Issue.RESOLUTION_FIXED:
+          return IssueStatus.FIXED;
+        default:
+      }
+    }
+
+
+    LOGGER.warn("Can't find mapped issue status for status '{}' and resolution '{}'", status, resolution);
+    return null;
+  }
+}
+

--- a/plugin-api/src/main/java/org/sonar/api/measures/CoreMetrics.java
+++ b/plugin-api/src/main/java/org/sonar/api/measures/CoreMetrics.java
@@ -999,12 +999,16 @@ public final class CoreMetrics {
 
   /**
    * @since 3.6
+   * @deprecated since 10.4. Use {@link #VIOLATIONS_KEY} instead.
    */
+  @Deprecated(since = "10.4")
   public static final String OPEN_ISSUES_KEY = "open_issues";
 
   /**
    * @since 3.6
+   * @deprecated since 10.4. Use {@link #VIOLATIONS} instead.
    */
+  @Deprecated(since = "10.4")
   public static final Metric<Integer> OPEN_ISSUES = new Metric.Builder(OPEN_ISSUES_KEY, "Open Issues", Metric.ValueType.INT)
     .setDescription("Open issues")
     .setDirection(Metric.DIRECTION_WORST)
@@ -1015,12 +1019,16 @@ public final class CoreMetrics {
 
   /**
    * @since 3.6
+   * @deprecated since 10.4. Use {@link #VIOLATIONS_KEY} instead.
    */
+  @Deprecated(since = "10.4")
   public static final String REOPENED_ISSUES_KEY = "reopened_issues";
 
   /**
    * @since 3.6
+   * @deprecated since 10.4. Use {@link #VIOLATIONS} instead.
    */
+  @Deprecated(since = "10.4")
   public static final Metric<Integer> REOPENED_ISSUES = new Metric.Builder(REOPENED_ISSUES_KEY, "Reopened Issues", Metric.ValueType.INT)
     .setDescription("Reopened issues")
     .setDirection(Metric.DIRECTION_WORST)
@@ -1032,12 +1040,16 @@ public final class CoreMetrics {
 
   /**
    * @since 3.6
+   * @deprecated since 10.4 as status {@link org.sonar.api.issue.Issue#STATUS_CONFIRMED} is deprecated. No replacement.
    */
+  @Deprecated(since = "10.4")
   public static final String CONFIRMED_ISSUES_KEY = "confirmed_issues";
 
   /**
    * @since 3.6
+   * @deprecated since 10.4 as status {@link org.sonar.api.issue.Issue#STATUS_CONFIRMED} is deprecated. No replacement.
    */
+  @Deprecated(since = "10.4")
   public static final Metric<Integer> CONFIRMED_ISSUES = new Metric.Builder(CONFIRMED_ISSUES_KEY, "Confirmed Issues", Metric.ValueType.INT)
     .setDescription("Confirmed issues")
     .setDirection(Metric.DIRECTION_WORST)

--- a/plugin-api/src/test/java/org/sonar/api/issue/IssueStatusTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/issue/IssueStatusTest.java
@@ -1,0 +1,81 @@
+/*
+ * Sonar Plugin API
+ * Copyright (C) 2009-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.api.issue;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.sonar.api.testfixtures.log.LogAndArguments;
+import org.sonar.api.testfixtures.log.LogTester;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class IssueStatusTest {
+  @Rule
+  public LogTester logTester = new LogTester();
+
+  @Test
+  public void of_shouldMapToCorrectIssueStatus() {
+    assertThat(IssueStatus.of(Issue.STATUS_RESOLVED, Issue.RESOLUTION_FIXED))
+      .isEqualTo(IssueStatus.FIXED);
+
+    assertThat(IssueStatus.of(Issue.STATUS_CONFIRMED, null))
+      .isEqualTo(IssueStatus.CONFIRMED);
+
+    assertThat(IssueStatus.of(Issue.STATUS_RESOLVED, Issue.RESOLUTION_FALSE_POSITIVE))
+      .isEqualTo(IssueStatus.FALSE_POSITIVE);
+
+    assertThat(IssueStatus.of(Issue.STATUS_RESOLVED, Issue.RESOLUTION_WONT_FIX))
+      .isEqualTo(IssueStatus.ACCEPTED);
+
+    assertThat(IssueStatus.of(Issue.STATUS_REOPENED, null))
+      .isEqualTo(IssueStatus.OPEN);
+
+    assertThat(IssueStatus.of(Issue.STATUS_CLOSED, null))
+      .isEqualTo(IssueStatus.FIXED);
+  }
+
+  @Test
+  public void of_shouldReturnNull_whenStatusBelongsToHotspot() {
+    assertThat(IssueStatus.of(Issue.STATUS_TO_REVIEW, null))
+      .isNull();
+
+    assertThat(IssueStatus.of(Issue.STATUS_REVIEWED, Issue.RESOLUTION_SAFE))
+      .isNull();
+
+    assertThat(IssueStatus.of(Issue.STATUS_REVIEWED, Issue.RESOLUTION_ACKNOWLEDGED))
+      .isNull();
+  }
+
+  @Test
+  public void of_shouldLogWarning_whenUnknownMapping() {
+    assertThat(IssueStatus.of(Issue.STATUS_RESOLVED, null)).isNull();
+    assertThat(logTester.getLogs()).extracting(LogAndArguments::getFormattedMsg).contains("Can't find mapped issue status for status 'RESOLVED' and resolution 'null'");
+
+    assertThat(IssueStatus.of(Issue.STATUS_RESOLVED, Issue.RESOLUTION_SAFE)).isNull();
+    assertThat(logTester.getLogs()).extracting(LogAndArguments::getFormattedMsg).contains("Can't find mapped issue status for status 'RESOLVED' and resolution 'SAFE'");
+  }
+
+  @Test
+  public void of_shouldLogWarning_whenStatusIsNull() {
+    assertThat(IssueStatus.of(null, null)).isEqualTo(IssueStatus.OPEN);
+    assertThat(logTester.getLogs()).extracting(LogAndArguments::getFormattedMsg).contains("Missing status, falling back to OPEN");
+  }
+
+}

--- a/test-fixtures/src/main/java/org/sonar/api/testfixtures/measure/TestIssue.java
+++ b/test-fixtures/src/main/java/org/sonar/api/testfixtures/measure/TestIssue.java
@@ -26,6 +26,7 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import org.sonar.api.ce.measure.Issue;
+import org.sonar.api.issue.IssueStatus;
 import org.sonar.api.issue.impact.SoftwareQuality;
 import org.sonar.api.rule.RuleKey;
 import org.sonar.api.rule.Severity;
@@ -68,15 +69,28 @@ public class TestIssue implements Issue {
     return ruleKey;
   }
 
+  /**
+   * @deprecated in favor of {@link Issue#issueStatus()}
+   */
   @Override
+  @Deprecated(since = "10.4")
   public String status() {
     return status;
   }
 
+  /**
+   * @deprecated in favor of {@link Issue#issueStatus()}
+   */
   @Override
   @CheckForNull
+  @Deprecated(since = "10.4")
   public String resolution() {
     return resolution;
+  }
+
+  @Override
+  public IssueStatus issueStatus() {
+    return IssueStatus.of(status, resolution);
   }
 
   @Override

--- a/test-fixtures/src/test/java/org/sonar/api/testfixtures/measure/TestIssueTest.java
+++ b/test-fixtures/src/test/java/org/sonar/api/testfixtures/measure/TestIssueTest.java
@@ -21,6 +21,7 @@ package org.sonar.api.testfixtures.measure;
 
 import org.junit.jupiter.api.Test;
 import org.sonar.api.ce.measure.Issue;
+import org.sonar.api.issue.IssueStatus;
 import org.sonar.api.issue.impact.SoftwareQuality;
 import org.sonar.api.rule.RuleKey;
 import org.sonar.api.rule.Severity;


### PR DESCRIPTION
# Context
In order to harmonize the new `issueStatus` field between products, it is interesting to put this new field (and the mapping with the old status/resolution) in the plugin-api. 
This proposal aims to show the user of the plugin-api what impacts etc.

# For SonarSourcers:

- [x] Create a [JIRA](http://jira.sonarsource.com/browse/PLUGINAPI) ticket if the API is impacted [this one](https://sonarsource.atlassian.net/jira/software/c/projects/PLUGINAPI/boards/393?selectedIssue=PLUGINAPI-72)
- [x] Prefix the commit message with the ticket number
- [x] Document the change in CHANGELOG.md
- [x] When adding a new API:
  - [ ] Explain in the JavaDoc the purpose of the new API
  - [x] Add a `@since X.Y` in the JavaDoc
- [x] When deprecating an API:
  - [x] Annotate the deprecated element with `@Deprecated`
  - [x] Add a `@deprecated since X.Y` in the JavaDoc
  - [x] Document the replacement in the JavaDoc (if any)
- [x] When dropping an API:
  - [x] Make sure it respects the [deprecation policy](https://github.com/SonarSource/sonar-plugin-api/blob/master/docs/deprecation-policy.md)
  - [x] Bump the major version (breaking change)
- [x] Make sure the tests adhere to the convention:
  - All test method names should use `snake_case`, for example: `test_validate_input`. It can also start with the `methodName`
- [ ] Make sure checks are green: build passes, Quality Gate is green
- [ ] Merge after getting approval by at least one member of the guild
  - If no review is made within 3 days, gently ping the reviewers
  - The guild member reviewing the code can explicitly request someone else (typically another guild member representing another team) to check the impact on the specific product 
  - In some cases, the guild may deem it necessary that multiple or even all members approve a PR. This is more likely in complex changes or changes directly impacting all teams using the API.


## Changelog : 
* 3b90311 PLUGINAPI-72 Deprecate 'status','resolution' in favor of 'issueStatus'
* 8df08bc fixup! fix review

## Squashed : 
* ffee13f PLUGINAPI-72 Deprecate 'status','resolution' in favor of 'issueStatus'

