### PR TITLE
PLUGINAPI-76 fixed misleading javadoc of org.sonar.api.config.Configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 10.4
+
+* Fixed misleading javadoc of `org.sonar.api.config.Configuration` to make it clear that at Compute Engine level project configuration is not provided.
+
 ## 10.3
 
 * Deprecate `org.sonar.api.measures.CoreMetrics.WONT_FIX_ISSUES` metric and related key.

--- a/plugin-api/src/main/java/org/sonar/api/config/Configuration.java
+++ b/plugin-api/src/main/java/org/sonar/api/config/Configuration.java
@@ -29,8 +29,7 @@ import org.sonarsource.api.sonarlint.SonarLintSide;
  * Component to get effective configuration. Values of properties depend on the runtime environment:
  * <ul>
  *   <li>immutable project configuration in scanner.</li>
- *   <li>global configuration in web server. It does not allow to get the settings overridden on projects.</li>
- *   <li>project configuration in Compute Engine.</li>
+ *   <li>global configuration in Web Server and Compute Engine. It does not allow to get the settings overridden on projects.</li>
  * </ul>
  *
  * <h3>Usage</h3>


### PR DESCRIPTION
Triggered by ticket https://sonarsource.atlassian.net/browse/SONAR-13711

Would be nice to check before merging if this is also the case for SonarCloud, although since SonarCloud doesn't have 3rd party plugins I don't think it is required.