### PR TITLE
BUILD-4839 Update the release workflow to the latest version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@5.0.1
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v5
     with:
       publishToBinaries: true
       mavenCentralSync: true


### PR DESCRIPTION
Release Action version 5.5.0 has been published. Update the release workflow to use the v5 branch for future updates. More details are at https://github.com/SonarSource/gh-action_release/releases.