### PR TITLE
PLUGINAPI-108 Remove environment from Jira integration

### DIFF
--- a/.github/workflows/PullRequestClosed.yml
+++ b/.github/workflows/PullRequestClosed.yml
@@ -8,7 +8,6 @@ jobs:
   PullRequestMerged_job:
     name: Pull Request Merged
     runs-on: ubuntu-latest
-    environment: jira
     permissions:
       id-token: write
       pull-requests: read

--- a/.github/workflows/PullRequestCreated.yml
+++ b/.github/workflows/PullRequestCreated.yml
@@ -8,7 +8,6 @@ jobs:
   PullRequestCreated_job:
     name: Pull Request Created
     runs-on: ubuntu-latest
-    environment: jira
     permissions:
       id-token: write
     # For external PR, ticket should be created manually

--- a/.github/workflows/RequestReview.yml
+++ b/.github/workflows/RequestReview.yml
@@ -8,7 +8,6 @@ jobs:
   RequestReview_job:
     name: Request review
     runs-on: ubuntu-latest
-    environment: jira
     permissions:
       id-token: write
     # For external PR, ticket should be moved manually

--- a/.github/workflows/SubmitReview.yml
+++ b/.github/workflows/SubmitReview.yml
@@ -8,7 +8,6 @@ jobs:
   SubmitReview_job:
     name: Submit Review
     runs-on: ubuntu-latest
-    environment: jira
     permissions:
       id-token: write
       pull-requests: read


### PR DESCRIPTION
[PLUGINAPI-108](https://sonarsource.atlassian.net/browse/PLUGINAPI-108)

I had a copy/paste issue in the previous PR https://github.com/SonarSource/sonar-plugin-api/pull/199

The `environment` parameter is not needed. The fact that this PR has a Jira issue created proves that it works (the GH action would fail immediately otherwise)

[PLUGINAPI-108]: https://sonarsource.atlassian.net/browse/PLUGINAPI-108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ