### PR TITLE
Change deprecated severity to org.sonar.api.issue.impact.Severity

### DIFF
--- a/plugin-api/src/main/java/org/sonar/api/server/profile/BuiltInQualityProfilesDefinition.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/profile/BuiltInQualityProfilesDefinition.java
@@ -31,7 +31,7 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import org.sonar.api.ExtensionPoint;
 import org.sonar.api.rule.RuleKey;
-import org.sonar.api.rule.Severity;
+import org.sonar.api.issue.impact.Severity;
 import org.sonar.api.server.ServerSide;
 
 import static java.lang.String.format;


### PR DESCRIPTION
Original code line 34.

import org.sonar.api.rule.Severity;
-----
Changed 

import org.sonar.api.issue.impact.Severity;
-----

It seems to be deprecated the original one. 
I tried to make my own language and rules.
And I Active the Rules and override the Severity with overrideSeverity()
But the BuiltInQualityProfilesDefinition still use the old Severity class. So I can't use HIGH, MEDIUM, LOW.
I think this part need to change new severity class.

please check this out. thanks