### PR TITLE
PLUGINAPI-118 Bump plugin API version for SQ:IDE to 11.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,12 @@ The following tables indicate which API versions plugins can find at runtime:
 Current version: 10.11.0.2468
 
 ### SonarQube for IDE
-| Flavor   | Plugin API   |
-|----------|--------------|
-| IntelliJ | 10.11.0.2468 |
-| Eclipse  | 10.11.0.2468 |
-| VSCode   | 10.11.0.2468 |
+| Flavor        | Plugin API   |
+|---------------|--------------|
+| Eclipse       | 11.1.0.2693  |
+| IntelliJ      | 11.1.0.2693  |
+| Visual Studio | 11.1.0.2693  |
+| VSCode        | 11.1.0.2693  |
 
 ## Optimizing the execution of sensors
 


### PR DESCRIPTION
[PLUGINAPI-118](https://sonarsource.atlassian.net/browse/PLUGINAPI-118)

SonarQube for IDE (VS Code, IntelliJ and Eclipse) were released with a version of sonarlint-core that implements plugin API 11.1

[PLUGINAPI-118]: https://sonarsource.atlassian.net/browse/PLUGINAPI-118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ