### PR TITLE
PLUGINAPI-136 Deprecate org.sonar.api.issues.DefaultTransitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 11.4
+* Deprecate `org.sonar.api.issue.DefaultTransitions`
 * Deprecate `org.sonar.api.web.UserRole`
 * Remove deprecated extension points ~~`org.sonar.api.profiles.ProfileExporter`~~ and ~~`org.sonar.api.profiles.ProfileImporter`~~.
 

--- a/plugin-api/src/main/java/org/sonar/api/issue/DefaultTransitions.java
+++ b/plugin-api/src/main/java/org/sonar/api/issue/DefaultTransitions.java
@@ -26,7 +26,9 @@ import static java.util.Collections.unmodifiableList;
 
 /**
  * @since 3.6
+ * @deprecated since 11.4 not used by any extension point anymore
  */
+@Deprecated(since = "11.4", forRemoval = true)
 public interface DefaultTransitions {
 
   /**


### PR DESCRIPTION
[PLUGINAPI-136](https://sonarsource.atlassian.net/browse/PLUGINAPI-136)



[PLUGINAPI-136]: https://sonarsource.atlassian.net/browse/PLUGINAPI-136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ