### PR TITLE
PLUGINAPI-167 Update license header from Sonarsource SA to SonarSource Sàrl

### DIFF
--- a/HEADER
+++ b/HEADER
@@ -1,5 +1,5 @@
 Sonar Plugin API
-Copyright (C) 2009-2025 SonarSource SA
+Copyright (C) 2009-2025 SonarSource Sàrl
 mailto:info AT sonarsource DOT com
 
 This program is free software; you can redistribute it and/or

--- a/check-api/src/main/java/org/sonar/check/BelongsToProfile.java
+++ b/check-api/src/main/java/org/sonar/check/BelongsToProfile.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/check-api/src/main/java/org/sonar/check/Cardinality.java
+++ b/check-api/src/main/java/org/sonar/check/Cardinality.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/check-api/src/main/java/org/sonar/check/Message.java
+++ b/check-api/src/main/java/org/sonar/check/Message.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/check-api/src/main/java/org/sonar/check/Priority.java
+++ b/check-api/src/main/java/org/sonar/check/Priority.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/check-api/src/main/java/org/sonar/check/Rule.java
+++ b/check-api/src/main/java/org/sonar/check/Rule.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/check-api/src/main/java/org/sonar/check/RuleProperty.java
+++ b/check-api/src/main/java/org/sonar/check/RuleProperty.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/check-api/src/main/java/org/sonar/check/package-info.java
+++ b/check-api/src/main/java/org/sonar/check/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/Beta.java
+++ b/plugin-api/src/main/java/org/sonar/api/Beta.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/CoreProperties.java
+++ b/plugin-api/src/main/java/org/sonar/api/CoreProperties.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/ExtensionPoint.java
+++ b/plugin-api/src/main/java/org/sonar/api/ExtensionPoint.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/Plugin.java
+++ b/plugin-api/src/main/java/org/sonar/api/Plugin.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/Properties.java
+++ b/plugin-api/src/main/java/org/sonar/api/Properties.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/Property.java
+++ b/plugin-api/src/main/java/org/sonar/api/Property.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/PropertyField.java
+++ b/plugin-api/src/main/java/org/sonar/api/PropertyField.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/PropertyType.java
+++ b/plugin-api/src/main/java/org/sonar/api/PropertyType.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/SonarEdition.java
+++ b/plugin-api/src/main/java/org/sonar/api/SonarEdition.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/SonarProduct.java
+++ b/plugin-api/src/main/java/org/sonar/api/SonarProduct.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/SonarQubeSide.java
+++ b/plugin-api/src/main/java/org/sonar/api/SonarQubeSide.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/SonarRuntime.java
+++ b/plugin-api/src/main/java/org/sonar/api/SonarRuntime.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/Startable.java
+++ b/plugin-api/src/main/java/org/sonar/api/Startable.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/a3s/A3SContextCollector.java
+++ b/plugin-api/src/main/java/org/sonar/api/a3s/A3SContextCollector.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/a3s/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/a3s/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/DependedUpon.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/DependedUpon.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/DependsUpon.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/DependsUpon.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/InstantiationStrategy.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/InstantiationStrategy.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/Phase.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/Phase.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/ScannerSide.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/ScannerSide.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/bootstrap/ProjectBuilder.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/bootstrap/ProjectBuilder.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/bootstrap/ProjectDefinition.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/bootstrap/ProjectDefinition.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/bootstrap/ProjectReactor.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/bootstrap/ProjectReactor.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/bootstrap/internal/ProjectBuilderContext.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/bootstrap/internal/ProjectBuilderContext.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/bootstrap/internal/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/bootstrap/internal/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/bootstrap/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/bootstrap/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/fs/FilePredicate.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/fs/FilePredicate.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/fs/FilePredicates.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/fs/FilePredicates.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/fs/FileSystem.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/fs/FileSystem.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/fs/IndexedFile.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/fs/IndexedFile.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/fs/InputComponent.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/fs/InputComponent.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/fs/InputDir.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/fs/InputDir.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/fs/InputFile.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/fs/InputFile.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/fs/InputFileFilter.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/fs/InputFileFilter.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/fs/InputModule.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/fs/InputModule.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/fs/InputPath.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/fs/InputPath.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/fs/TextPointer.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/fs/TextPointer.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/fs/TextRange.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/fs/TextRange.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/fs/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/fs/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/measure/Metric.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/measure/Metric.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/measure/MetricFinder.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/measure/MetricFinder.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/measure/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/measure/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/postjob/PostJob.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/postjob/PostJob.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/postjob/PostJobContext.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/postjob/PostJobContext.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/postjob/PostJobDescriptor.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/postjob/PostJobDescriptor.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/postjob/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/postjob/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/rule/ActiveRule.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/rule/ActiveRule.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/rule/ActiveRules.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/rule/ActiveRules.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/rule/CheckFactory.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/rule/CheckFactory.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/rule/Checks.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/rule/Checks.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/rule/LoadedActiveRule.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/rule/LoadedActiveRule.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/rule/Rule.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/rule/Rule.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/rule/RuleParam.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/rule/RuleParam.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/rule/Severity.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/rule/Severity.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/rule/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/rule/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/scm/BlameCommand.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/scm/BlameCommand.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/scm/BlameLine.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/scm/BlameLine.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/scm/IgnoreCommand.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/scm/IgnoreCommand.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/scm/ScmProvider.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/scm/ScmProvider.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/scm/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/scm/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/Sensor.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/Sensor.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/SensorContext.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/SensorContext.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or
@@ -272,12 +272,12 @@ public interface SensorContext {
    * For performance reason, the telemetry properties should be limited to a small set of key-value pairs.
    * For GDPR compliance, the telemetry properties should not contain any personal or identifying data.
    * <br/>
-   * This method can not be used by plugins not developed by SonarSource SA.
+   * This method can not be used by plugins not developed by SonarSource Sàrl.
    *
    * @param key The key must follow this convention: &lt;pluginKey&gt;.&lt;entryKey&gt;. Example: cfamily.qualityIndex
    *
    * @throws IllegalArgumentException if key or value parameter is null
-   * @throws IllegalStateException if the method is called by a plugin not developed by SonarSource SA
+   * @throws IllegalStateException if the method is called by a plugin not developed by SonarSource Sàrl
    * @since 10.9
    */
   void addTelemetryProperty(String key, String value);
@@ -291,7 +291,7 @@ public interface SensorContext {
    * @param data The binary data to be added. The InputStream will be consumed once then closed during the method execution.
    *
    * @throws IllegalArgumentException if key, mimeType, or data parameter is null or invalid
-   * @throws IllegalStateException if the method is called by a plugin not developed by SonarSource SA
+   * @throws IllegalStateException if the method is called by a plugin not developed by SonarSource Sàrl
    * @since 11.3
    */
   @Beta

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/SensorDescriptor.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/SensorDescriptor.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/cache/ReadCache.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/cache/ReadCache.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/cache/WriteCache.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/cache/WriteCache.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/cache/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/cache/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/code/NewSignificantCode.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/code/NewSignificantCode.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/code/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/code/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/coverage/NewCoverage.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/coverage/NewCoverage.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/coverage/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/coverage/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/cpd/NewCpdTokens.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/cpd/NewCpdTokens.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/cpd/internal/TokensLine.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/cpd/internal/TokensLine.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/cpd/internal/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/cpd/internal/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/cpd/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/cpd/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/error/AnalysisError.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/error/AnalysisError.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/error/NewAnalysisError.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/error/NewAnalysisError.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/error/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/error/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/highlighting/NewHighlighting.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/highlighting/NewHighlighting.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/highlighting/TypeOfText.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/highlighting/TypeOfText.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/highlighting/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/highlighting/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/internal/SensorStorage.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/internal/SensorStorage.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/internal/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/internal/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/issue/ExternalIssue.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/issue/ExternalIssue.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/issue/IIssue.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/issue/IIssue.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/issue/Issue.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/issue/Issue.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/issue/IssueLocation.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/issue/IssueLocation.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/issue/MessageFormatting.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/issue/MessageFormatting.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/issue/NewExternalIssue.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/issue/NewExternalIssue.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/issue/NewIssue.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/issue/NewIssue.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/issue/NewIssueLocation.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/issue/NewIssueLocation.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/issue/NewMessageFormatting.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/issue/NewMessageFormatting.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/issue/fix/InputFileEdit.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/issue/fix/InputFileEdit.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/issue/fix/NewInputFileEdit.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/issue/fix/NewInputFileEdit.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/issue/fix/NewQuickFix.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/issue/fix/NewQuickFix.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/issue/fix/NewTextEdit.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/issue/fix/NewTextEdit.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/issue/fix/QuickFix.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/issue/fix/QuickFix.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/issue/fix/TextEdit.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/issue/fix/TextEdit.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/issue/fix/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/issue/fix/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/issue/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/issue/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/measure/Measure.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/measure/Measure.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/measure/NewMeasure.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/measure/NewMeasure.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/measure/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/measure/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/rule/AdHocRule.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/rule/AdHocRule.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/rule/NewAdHocRule.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/rule/NewAdHocRule.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/rule/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/rule/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/symbol/NewSymbol.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/symbol/NewSymbol.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/symbol/NewSymbolTable.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/symbol/NewSymbolTable.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/batch/sensor/symbol/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/sensor/symbol/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/ce/ComputeEngineSide.java
+++ b/plugin-api/src/main/java/org/sonar/api/ce/ComputeEngineSide.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/ce/measure/Component.java
+++ b/plugin-api/src/main/java/org/sonar/api/ce/measure/Component.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/ce/measure/Issue.java
+++ b/plugin-api/src/main/java/org/sonar/api/ce/measure/Issue.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/ce/measure/Measure.java
+++ b/plugin-api/src/main/java/org/sonar/api/ce/measure/Measure.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/ce/measure/MeasureComputer.java
+++ b/plugin-api/src/main/java/org/sonar/api/ce/measure/MeasureComputer.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/ce/measure/RangeDistributionBuilder.java
+++ b/plugin-api/src/main/java/org/sonar/api/ce/measure/RangeDistributionBuilder.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/ce/measure/Settings.java
+++ b/plugin-api/src/main/java/org/sonar/api/ce/measure/Settings.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/ce/measure/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/ce/measure/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/ce/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/ce/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/ce/posttask/Analysis.java
+++ b/plugin-api/src/main/java/org/sonar/api/ce/posttask/Analysis.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/ce/posttask/Branch.java
+++ b/plugin-api/src/main/java/org/sonar/api/ce/posttask/Branch.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/ce/posttask/CeTask.java
+++ b/plugin-api/src/main/java/org/sonar/api/ce/posttask/CeTask.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/ce/posttask/Organization.java
+++ b/plugin-api/src/main/java/org/sonar/api/ce/posttask/Organization.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/ce/posttask/PostProjectAnalysisTask.java
+++ b/plugin-api/src/main/java/org/sonar/api/ce/posttask/PostProjectAnalysisTask.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/ce/posttask/Project.java
+++ b/plugin-api/src/main/java/org/sonar/api/ce/posttask/Project.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/ce/posttask/QualityGate.java
+++ b/plugin-api/src/main/java/org/sonar/api/ce/posttask/QualityGate.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/ce/posttask/ScannerContext.java
+++ b/plugin-api/src/main/java/org/sonar/api/ce/posttask/ScannerContext.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/ce/posttask/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/ce/posttask/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/config/Category.java
+++ b/plugin-api/src/main/java/org/sonar/api/config/Category.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/config/Configuration.java
+++ b/plugin-api/src/main/java/org/sonar/api/config/Configuration.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/config/EmailSettings.java
+++ b/plugin-api/src/main/java/org/sonar/api/config/EmailSettings.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/config/GlobalPropertyChangeHandler.java
+++ b/plugin-api/src/main/java/org/sonar/api/config/GlobalPropertyChangeHandler.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/config/PropertyDefinition.java
+++ b/plugin-api/src/main/java/org/sonar/api/config/PropertyDefinition.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/config/PropertyDefinitions.java
+++ b/plugin-api/src/main/java/org/sonar/api/config/PropertyDefinitions.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/config/PropertyFieldDefinition.java
+++ b/plugin-api/src/main/java/org/sonar/api/config/PropertyFieldDefinition.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/config/Settings.java
+++ b/plugin-api/src/main/java/org/sonar/api/config/Settings.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/config/SubCategory.java
+++ b/plugin-api/src/main/java/org/sonar/api/config/SubCategory.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/config/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/config/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/issue/DefaultTransitions.java
+++ b/plugin-api/src/main/java/org/sonar/api/issue/DefaultTransitions.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/issue/Issue.java
+++ b/plugin-api/src/main/java/org/sonar/api/issue/Issue.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/issue/IssueStatus.java
+++ b/plugin-api/src/main/java/org/sonar/api/issue/IssueStatus.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/issue/NoSonarFilter.java
+++ b/plugin-api/src/main/java/org/sonar/api/issue/NoSonarFilter.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/issue/impact/Severity.java
+++ b/plugin-api/src/main/java/org/sonar/api/issue/impact/Severity.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/issue/impact/SoftwareQuality.java
+++ b/plugin-api/src/main/java/org/sonar/api/issue/impact/SoftwareQuality.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/issue/impact/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/issue/impact/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/issue/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/issue/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/measures/CoreMetrics.java
+++ b/plugin-api/src/main/java/org/sonar/api/measures/CoreMetrics.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/measures/FileLinesContext.java
+++ b/plugin-api/src/main/java/org/sonar/api/measures/FileLinesContext.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/measures/FileLinesContextFactory.java
+++ b/plugin-api/src/main/java/org/sonar/api/measures/FileLinesContextFactory.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/measures/Metric.java
+++ b/plugin-api/src/main/java/org/sonar/api/measures/Metric.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/measures/Metrics.java
+++ b/plugin-api/src/main/java/org/sonar/api/measures/Metrics.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/measures/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/measures/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/notifications/AnalysisWarnings.java
+++ b/plugin-api/src/main/java/org/sonar/api/notifications/AnalysisWarnings.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/notifications/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/notifications/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/platform/NewUserHandler.java
+++ b/plugin-api/src/main/java/org/sonar/api/platform/NewUserHandler.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/platform/Server.java
+++ b/plugin-api/src/main/java/org/sonar/api/platform/Server.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/platform/ServerFileSystem.java
+++ b/plugin-api/src/main/java/org/sonar/api/platform/ServerFileSystem.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/platform/ServerStartHandler.java
+++ b/plugin-api/src/main/java/org/sonar/api/platform/ServerStartHandler.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/platform/ServerStopHandler.java
+++ b/plugin-api/src/main/java/org/sonar/api/platform/ServerStopHandler.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/platform/ServerUpgradeStatus.java
+++ b/plugin-api/src/main/java/org/sonar/api/platform/ServerUpgradeStatus.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/platform/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/platform/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/resources/AbstractLanguage.java
+++ b/plugin-api/src/main/java/org/sonar/api/resources/AbstractLanguage.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/resources/Language.java
+++ b/plugin-api/src/main/java/org/sonar/api/resources/Language.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/resources/Languages.java
+++ b/plugin-api/src/main/java/org/sonar/api/resources/Languages.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/resources/Qualifiers.java
+++ b/plugin-api/src/main/java/org/sonar/api/resources/Qualifiers.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/resources/ResourceType.java
+++ b/plugin-api/src/main/java/org/sonar/api/resources/ResourceType.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/resources/ResourceTypeTree.java
+++ b/plugin-api/src/main/java/org/sonar/api/resources/ResourceTypeTree.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/resources/ResourceTypes.java
+++ b/plugin-api/src/main/java/org/sonar/api/resources/ResourceTypes.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/resources/Scopes.java
+++ b/plugin-api/src/main/java/org/sonar/api/resources/Scopes.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/resources/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/resources/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/rule/RuleKey.java
+++ b/plugin-api/src/main/java/org/sonar/api/rule/RuleKey.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/rule/RuleScope.java
+++ b/plugin-api/src/main/java/org/sonar/api/rule/RuleScope.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/rule/RuleStatus.java
+++ b/plugin-api/src/main/java/org/sonar/api/rule/RuleStatus.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/rule/Severity.java
+++ b/plugin-api/src/main/java/org/sonar/api/rule/Severity.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/rule/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/rule/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/rules/CleanCodeAttribute.java
+++ b/plugin-api/src/main/java/org/sonar/api/rules/CleanCodeAttribute.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/rules/CleanCodeAttributeCategory.java
+++ b/plugin-api/src/main/java/org/sonar/api/rules/CleanCodeAttributeCategory.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/rules/Rule.java
+++ b/plugin-api/src/main/java/org/sonar/api/rules/Rule.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/rules/RuleAnnotationUtils.java
+++ b/plugin-api/src/main/java/org/sonar/api/rules/RuleAnnotationUtils.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/rules/RuleFinder.java
+++ b/plugin-api/src/main/java/org/sonar/api/rules/RuleFinder.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/rules/RuleParam.java
+++ b/plugin-api/src/main/java/org/sonar/api/rules/RuleParam.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/rules/RulePriority.java
+++ b/plugin-api/src/main/java/org/sonar/api/rules/RulePriority.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/rules/RuleQuery.java
+++ b/plugin-api/src/main/java/org/sonar/api/rules/RuleQuery.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/rules/RuleType.java
+++ b/plugin-api/src/main/java/org/sonar/api/rules/RuleType.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/rules/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/rules/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/scan/filesystem/FileExclusions.java
+++ b/plugin-api/src/main/java/org/sonar/api/scan/filesystem/FileExclusions.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/scan/filesystem/PathResolver.java
+++ b/plugin-api/src/main/java/org/sonar/api/scan/filesystem/PathResolver.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/scan/filesystem/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/scan/filesystem/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/scan/issue/filter/FilterableIssue.java
+++ b/plugin-api/src/main/java/org/sonar/api/scan/issue/filter/FilterableIssue.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/scan/issue/filter/IssueFilter.java
+++ b/plugin-api/src/main/java/org/sonar/api/scan/issue/filter/IssueFilter.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/scan/issue/filter/IssueFilterChain.java
+++ b/plugin-api/src/main/java/org/sonar/api/scan/issue/filter/IssueFilterChain.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/scan/issue/filter/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/scan/issue/filter/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/scanner/ScannerSide.java
+++ b/plugin-api/src/main/java/org/sonar/api/scanner/ScannerSide.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/scanner/fs/InputProject.java
+++ b/plugin-api/src/main/java/org/sonar/api/scanner/fs/InputProject.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/scanner/fs/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/scanner/fs/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/scanner/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/scanner/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/scanner/sensor/ProjectSensor.java
+++ b/plugin-api/src/main/java/org/sonar/api/scanner/sensor/ProjectSensor.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/scanner/sensor/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/scanner/sensor/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/security/Authenticator.java
+++ b/plugin-api/src/main/java/org/sonar/api/security/Authenticator.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/security/DefaultGroups.java
+++ b/plugin-api/src/main/java/org/sonar/api/security/DefaultGroups.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/security/ExternalGroupsProvider.java
+++ b/plugin-api/src/main/java/org/sonar/api/security/ExternalGroupsProvider.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/security/ExternalUsersProvider.java
+++ b/plugin-api/src/main/java/org/sonar/api/security/ExternalUsersProvider.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/security/SecurityRealm.java
+++ b/plugin-api/src/main/java/org/sonar/api/security/SecurityRealm.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/security/UserDetails.java
+++ b/plugin-api/src/main/java/org/sonar/api/security/UserDetails.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/security/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/security/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/ServerSide.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/ServerSide.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/authentication/BaseIdentityProvider.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/authentication/BaseIdentityProvider.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/authentication/Display.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/authentication/Display.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/authentication/IdentityProvider.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/authentication/IdentityProvider.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/authentication/OAuth2IdentityProvider.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/authentication/OAuth2IdentityProvider.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/authentication/UnauthorizedException.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/authentication/UnauthorizedException.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/authentication/UserIdentity.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/authentication/UserIdentity.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/authentication/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/authentication/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/debt/DebtRemediationFunction.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/debt/DebtRemediationFunction.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/debt/internal/DefaultDebtRemediationFunction.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/debt/internal/DefaultDebtRemediationFunction.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/debt/internal/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/debt/internal/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/debt/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/debt/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/http/Cookie.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/http/Cookie.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/http/HttpRequest.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/http/HttpRequest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/http/HttpResponse.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/http/HttpResponse.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/impl/RulesDefinitionContext.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/impl/RulesDefinitionContext.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/profile/BuiltInQualityProfileAnnotationLoader.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/profile/BuiltInQualityProfileAnnotationLoader.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/profile/BuiltInQualityProfilesDefinition.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/profile/BuiltInQualityProfilesDefinition.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/profile/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/profile/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/rule/Context.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/rule/Context.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/rule/ContextAwareRuleDescriptionSection.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/rule/ContextAwareRuleDescriptionSection.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/rule/DefaultRuleDescriptionSection.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/rule/DefaultRuleDescriptionSection.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/rule/RuleDescriptionSection.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/rule/RuleDescriptionSection.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/rule/RuleDescriptionSectionBuilder.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/rule/RuleDescriptionSectionBuilder.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/rule/RuleParamType.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/rule/RuleParamType.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/rule/RuleTagFormat.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/rule/RuleTagFormat.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/rule/RuleTagsToTypeConverter.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/rule/RuleTagsToTypeConverter.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/rule/RulesDefinition.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/rule/RulesDefinition.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/rule/RulesDefinitionAnnotationLoader.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/rule/RulesDefinitionAnnotationLoader.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/rule/RulesDefinitionXmlLoader.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/rule/RulesDefinitionXmlLoader.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/rule/StringPatternValidator.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/rule/StringPatternValidator.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/rule/internal/DefaultDebtRemediationFunctions.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/rule/internal/DefaultDebtRemediationFunctions.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/rule/internal/DefaultNewParam.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/rule/internal/DefaultNewParam.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/rule/internal/DefaultNewRepository.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/rule/internal/DefaultNewRepository.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/rule/internal/DefaultNewRule.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/rule/internal/DefaultNewRule.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/rule/internal/DefaultParam.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/rule/internal/DefaultParam.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/rule/internal/DefaultRepository.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/rule/internal/DefaultRepository.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/rule/internal/DefaultRule.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/rule/internal/DefaultRule.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/rule/internal/ImpactMapper.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/rule/internal/ImpactMapper.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/rule/internal/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/rule/internal/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/rule/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/rule/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/ws/Change.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/ws/Change.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/ws/Definable.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/ws/Definable.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/ws/LocalConnector.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/ws/LocalConnector.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/ws/Request.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/ws/Request.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/ws/RequestHandler.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/ws/RequestHandler.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/ws/Response.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/ws/Response.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/ws/WebService.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/ws/WebService.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/ws/impl/PartImpl.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/ws/impl/PartImpl.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/ws/impl/ValidatingRequest.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/ws/impl/ValidatingRequest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/server/ws/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/ws/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/user/User.java
+++ b/plugin-api/src/main/java/org/sonar/api/user/User.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/user/UserGroupValidation.java
+++ b/plugin-api/src/main/java/org/sonar/api/user/UserGroupValidation.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/user/UserQuery.java
+++ b/plugin-api/src/main/java/org/sonar/api/user/UserQuery.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/user/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/user/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/AnnotationUtils.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/AnnotationUtils.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/DateUtils.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/DateUtils.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/Duration.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/Duration.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/Durations.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/Durations.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/FieldUtils2.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/FieldUtils2.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/HttpDownloader.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/HttpDownloader.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/KeyValueFormat.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/KeyValueFormat.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/LocalizedMessages.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/LocalizedMessages.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/ManifestUtils.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/ManifestUtils.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/MessageException.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/MessageException.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/Paging.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/Paging.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/ParsingUtils.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/ParsingUtils.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/PathUtils.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/PathUtils.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/Preconditions.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/Preconditions.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/SonarException.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/SonarException.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/System2.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/System2.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/TempFolder.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/TempFolder.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/TimeUtils.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/TimeUtils.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/UriReader.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/UriReader.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/ValidationMessages.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/ValidationMessages.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/Version.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/Version.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/WildcardPattern.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/WildcardPattern.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/ZipUtils.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/ZipUtils.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/command/Command.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/command/Command.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/command/CommandException.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/command/CommandException.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/command/CommandExecutor.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/command/CommandExecutor.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/command/StreamConsumer.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/command/StreamConsumer.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/command/StringStreamConsumer.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/command/StringStreamConsumer.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/command/TimeoutException.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/command/TimeoutException.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/command/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/command/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/dag/CyclicDependenciesException.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/dag/CyclicDependenciesException.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/dag/DirectAcyclicGraph.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/dag/DirectAcyclicGraph.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/dag/Node.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/dag/Node.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/dag/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/dag/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/log/DefaultProfiler.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/log/DefaultProfiler.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/log/Logger.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/log/Logger.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/log/LoggerLevel.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/log/LoggerLevel.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/log/Loggers.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/log/Loggers.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/log/NullProfiler.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/log/NullProfiler.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/log/Profiler.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/log/Profiler.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/log/Slf4jLogger.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/log/Slf4jLogger.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/log/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/log/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/text/CsvWriter.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/text/CsvWriter.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/text/JsonWriter.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/text/JsonWriter.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/text/WriterException.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/text/WriterException.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/text/XmlWriter.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/text/XmlWriter.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/utils/text/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/utils/text/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/web/AbstractUrlPattern.java
+++ b/plugin-api/src/main/java/org/sonar/api/web/AbstractUrlPattern.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/web/FilterChain.java
+++ b/plugin-api/src/main/java/org/sonar/api/web/FilterChain.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/web/HttpFilter.java
+++ b/plugin-api/src/main/java/org/sonar/api/web/HttpFilter.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/web/UrlPattern.java
+++ b/plugin-api/src/main/java/org/sonar/api/web/UrlPattern.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/web/UserRole.java
+++ b/plugin-api/src/main/java/org/sonar/api/web/UserRole.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/web/WebAnalytics.java
+++ b/plugin-api/src/main/java/org/sonar/api/web/WebAnalytics.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/web/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/web/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/web/page/Context.java
+++ b/plugin-api/src/main/java/org/sonar/api/web/page/Context.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/web/page/Page.java
+++ b/plugin-api/src/main/java/org/sonar/api/web/page/Page.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/web/page/PageDefinition.java
+++ b/plugin-api/src/main/java/org/sonar/api/web/page/PageDefinition.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonar/api/web/page/package-info.java
+++ b/plugin-api/src/main/java/org/sonar/api/web/page/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonarsource/api/sonarlint/SonarLintSide.java
+++ b/plugin-api/src/main/java/org/sonarsource/api/sonarlint/SonarLintSide.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/main/java/org/sonarsource/api/sonarlint/package-info.java
+++ b/plugin-api/src/main/java/org/sonarsource/api/sonarlint/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/batch/bootstrap/ProjectBuilderTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/batch/bootstrap/ProjectBuilderTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/batch/bootstrap/ProjectDefinitionTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/batch/bootstrap/ProjectDefinitionTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/batch/bootstrap/ProjectReactorTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/batch/bootstrap/ProjectReactorTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/batch/fs/IndexedFileTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/batch/fs/IndexedFileTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/batch/rule/AbstractCheck.java
+++ b/plugin-api/src/test/java/org/sonar/api/batch/rule/AbstractCheck.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/batch/rule/CheckWithKey.java
+++ b/plugin-api/src/test/java/org/sonar/api/batch/rule/CheckWithKey.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/batch/rule/CheckWithOverriddenPropertyKey.java
+++ b/plugin-api/src/test/java/org/sonar/api/batch/rule/CheckWithOverriddenPropertyKey.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/batch/rule/CheckWithPrimitiveProperties.java
+++ b/plugin-api/src/test/java/org/sonar/api/batch/rule/CheckWithPrimitiveProperties.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/batch/rule/CheckWithStringProperty.java
+++ b/plugin-api/src/test/java/org/sonar/api/batch/rule/CheckWithStringProperty.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/batch/rule/CheckWithUnsupportedPropertyType.java
+++ b/plugin-api/src/test/java/org/sonar/api/batch/rule/CheckWithUnsupportedPropertyType.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/batch/rule/CheckWithoutProperties.java
+++ b/plugin-api/src/test/java/org/sonar/api/batch/rule/CheckWithoutProperties.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/batch/rule/ChecksTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/batch/rule/ChecksTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/batch/rule/ImplementedCheck.java
+++ b/plugin-api/src/test/java/org/sonar/api/batch/rule/ImplementedCheck.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/batch/scm/BlameLineTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/batch/scm/BlameLineTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/batch/scm/ScmProviderTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/batch/scm/ScmProviderTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/batch/sensor/highlighting/TypeOfTextTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/batch/sensor/highlighting/TypeOfTextTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/ce/measure/RangeDistributionBuilderTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/ce/measure/RangeDistributionBuilderTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/ce/posttask/CeTaskBuilder_PostProjectAnalysisTaskTesterTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/ce/posttask/CeTaskBuilder_PostProjectAnalysisTaskTesterTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/ce/posttask/ConditionBuilder_PostProjectAnalysisTaskTesterTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/ce/posttask/ConditionBuilder_PostProjectAnalysisTaskTesterTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/ce/posttask/PostProjectAnalysisTaskTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/ce/posttask/PostProjectAnalysisTaskTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/ce/posttask/ProjectBuilder_PostProjectAnalysisTaskTesterTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/ce/posttask/ProjectBuilder_PostProjectAnalysisTaskTesterTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/ce/posttask/QualityGateBuilder_PostProjectAnalysisTaskTesterTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/ce/posttask/QualityGateBuilder_PostProjectAnalysisTaskTesterTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/config/CategoryTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/config/CategoryTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/config/ConfigurationTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/config/ConfigurationTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/config/EmailSettingsTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/config/EmailSettingsTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/config/GlobalPropertyChangeHandlerTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/config/GlobalPropertyChangeHandlerTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/config/MapConfiguration.java
+++ b/plugin-api/src/test/java/org/sonar/api/config/MapConfiguration.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/config/PropertyDefinitionTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/config/PropertyDefinitionTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/config/PropertyDefinitionsTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/config/PropertyDefinitionsTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/config/SettingsTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/config/SettingsTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/config/SubCategoryTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/config/SubCategoryTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/issue/DefaultTransitionsTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/issue/DefaultTransitionsTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/issue/IssueStatusTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/issue/IssueStatusTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/issue/IssueTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/issue/IssueTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/measures/MetricTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/measures/MetricTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/platform/NewUserHandlerTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/platform/NewUserHandlerTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/resources/AbstractLanguageTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/resources/AbstractLanguageTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/resources/CoreMetricsTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/resources/CoreMetricsTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/resources/LanguagesTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/resources/LanguagesTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/resources/ResourceTypeTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/resources/ResourceTypeTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/resources/ResourceTypeTreeTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/resources/ResourceTypeTreeTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/resources/ResourceTypesTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/resources/ResourceTypesTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/resources/ScopesTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/resources/ScopesTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/rule/RuleKeyTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/rule/RuleKeyTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/rule/RuleStatusTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/rule/RuleStatusTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/rule/SeverityTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/rule/SeverityTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/rules/AnnotatedCheck.java
+++ b/plugin-api/src/test/java/org/sonar/api/rules/AnnotatedCheck.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/rules/AnnotatedCheckWithParameters.java
+++ b/plugin-api/src/test/java/org/sonar/api/rules/AnnotatedCheckWithParameters.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/rules/CleanCodeAttributeTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/rules/CleanCodeAttributeTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/rules/RuleAnnotationUtilsTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/rules/RuleAnnotationUtilsTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/rules/RulePriorityTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/rules/RulePriorityTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/rules/RuleTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/rules/RuleTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/rules/RuleTypeTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/rules/RuleTypeTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/scan/filesystem/FileExclusionsTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/scan/filesystem/FileExclusionsTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/scan/filesystem/PathResolverTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/scan/filesystem/PathResolverTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/security/DefaultGroupsTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/security/DefaultGroupsTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/security/ExternalGroupsProviderTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/security/ExternalGroupsProviderTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/security/ExternalUsersProviderTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/security/ExternalUsersProviderTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/security/SecurityRealmTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/security/SecurityRealmTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/security/UserDetailsTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/security/UserDetailsTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/server/authentication/DisplayTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/server/authentication/DisplayTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/server/authentication/UserIdentityTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/server/authentication/UserIdentityTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/server/debt/DefaultDebtRemediationFunctionTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/server/debt/DefaultDebtRemediationFunctionTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/server/impl/RulesDefinitionContextTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/server/impl/RulesDefinitionContextTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/server/profile/BuiltInQualityProfileAnnotationLoaderTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/server/profile/BuiltInQualityProfileAnnotationLoaderTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/server/profile/BuiltInQualityProfilesDefinitionTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/server/profile/BuiltInQualityProfilesDefinitionTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/server/rule/ContextAwareRuleDescriptionSectionTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/server/rule/ContextAwareRuleDescriptionSectionTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/server/rule/ContextTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/server/rule/ContextTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/server/rule/DefaultRuleDescriptionSectionTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/server/rule/DefaultRuleDescriptionSectionTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/server/rule/RuleDescriptionSectionBuilderTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/server/rule/RuleDescriptionSectionBuilderTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/server/rule/RuleParamTypeTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/server/rule/RuleParamTypeTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/server/rule/RuleTagFormatTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/server/rule/RuleTagFormatTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/server/rule/RuleTagsToTypeConverterTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/server/rule/RuleTagsToTypeConverterTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/server/rule/RulesDefinitionAnnotationLoaderTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/server/rule/RulesDefinitionAnnotationLoaderTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/server/rule/RulesDefinitionXmlLoaderTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/server/rule/RulesDefinitionXmlLoaderTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/server/rule/StringPatternValidatorTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/server/rule/StringPatternValidatorTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/server/rule/internal/DefaultNewRuleTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/server/rule/internal/DefaultNewRuleTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/server/rule/internal/DefaultRepositoryTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/server/rule/internal/DefaultRepositoryTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/server/rule/internal/DefaultRuleTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/server/rule/internal/DefaultRuleTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/server/rule/internal/ImpactMapperTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/server/rule/internal/ImpactMapperTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/server/ws/RequestTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/server/ws/RequestTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/server/ws/WebServiceTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/server/ws/WebServiceTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/user/UserGroupValidationTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/user/UserGroupValidationTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/user/UserQueryTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/user/UserQueryTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/utils/AnnotationUtilsTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/utils/AnnotationUtilsTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/utils/DateUtilsTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/utils/DateUtilsTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/utils/DurationTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/utils/DurationTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/utils/DurationsTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/utils/DurationsTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/utils/ExceptionCauseMatcher.java
+++ b/plugin-api/src/test/java/org/sonar/api/utils/ExceptionCauseMatcher.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/utils/FieldUtils2Test.java
+++ b/plugin-api/src/test/java/org/sonar/api/utils/FieldUtils2Test.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/utils/KeyValueFormatTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/utils/KeyValueFormatTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/utils/LocalizedMessagesTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/utils/LocalizedMessagesTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/utils/ManifestUtilsTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/utils/ManifestUtilsTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/utils/MessageExceptionTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/utils/MessageExceptionTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/utils/PagingTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/utils/PagingTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/utils/ParsingUtilsTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/utils/ParsingUtilsTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/utils/PathUtilsTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/utils/PathUtilsTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/utils/System2Test.java
+++ b/plugin-api/src/test/java/org/sonar/api/utils/System2Test.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/utils/TestUtils.java
+++ b/plugin-api/src/test/java/org/sonar/api/utils/TestUtils.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/utils/TimeUtilsTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/utils/TimeUtilsTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/utils/UriReaderTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/utils/UriReaderTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/utils/ValidationMessagesTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/utils/ValidationMessagesTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/utils/VersionTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/utils/VersionTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/utils/WildcardPatternTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/utils/WildcardPatternTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/utils/ZipUtilsTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/utils/ZipUtilsTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/utils/command/CommandExecutorTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/utils/command/CommandExecutorTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/utils/command/CommandTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/utils/command/CommandTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/utils/dag/DirectAcyclicGraphTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/utils/dag/DirectAcyclicGraphTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/utils/log/DefaultProfilerTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/utils/log/DefaultProfilerTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/utils/log/LoggersTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/utils/log/LoggersTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/utils/log/NullProfilerTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/utils/log/NullProfilerTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/utils/log/ProfilerTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/utils/log/ProfilerTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/utils/log/Slf4jLoggerTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/utils/log/Slf4jLoggerTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/utils/text/CsvWriterTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/utils/text/CsvWriterTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/utils/text/JsonWriterTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/utils/text/JsonWriterTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/utils/text/XmlWriterTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/utils/text/XmlWriterTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/web/HttpFilterTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/web/HttpFilterTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/web/UrlPatternTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/web/UrlPatternTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/web/page/ContextTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/web/page/ContextTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/web/page/PageDefinitionTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/web/page/PageDefinitionTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin-api/src/test/java/org/sonar/api/web/page/PageTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/web/page/PageTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/test-fixtures/src/main/java/org/sonar/api/testfixtures/log/AbstractLogTester.java
+++ b/test-fixtures/src/main/java/org/sonar/api/testfixtures/log/AbstractLogTester.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/test-fixtures/src/main/java/org/sonar/api/testfixtures/log/ConcurrentListAppender.java
+++ b/test-fixtures/src/main/java/org/sonar/api/testfixtures/log/ConcurrentListAppender.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/test-fixtures/src/main/java/org/sonar/api/testfixtures/log/LogAndArguments.java
+++ b/test-fixtures/src/main/java/org/sonar/api/testfixtures/log/LogAndArguments.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/test-fixtures/src/main/java/org/sonar/api/testfixtures/log/LogTester.java
+++ b/test-fixtures/src/main/java/org/sonar/api/testfixtures/log/LogTester.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/test-fixtures/src/main/java/org/sonar/api/testfixtures/log/LogTesterJUnit5.java
+++ b/test-fixtures/src/main/java/org/sonar/api/testfixtures/log/LogTesterJUnit5.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/test-fixtures/src/main/java/org/sonar/api/testfixtures/measure/TestComponent.java
+++ b/test-fixtures/src/main/java/org/sonar/api/testfixtures/measure/TestComponent.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/test-fixtures/src/main/java/org/sonar/api/testfixtures/measure/TestIssue.java
+++ b/test-fixtures/src/main/java/org/sonar/api/testfixtures/measure/TestIssue.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/test-fixtures/src/main/java/org/sonar/api/testfixtures/measure/TestMeasure.java
+++ b/test-fixtures/src/main/java/org/sonar/api/testfixtures/measure/TestMeasure.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/test-fixtures/src/main/java/org/sonar/api/testfixtures/measure/TestMeasureComputerContext.java
+++ b/test-fixtures/src/main/java/org/sonar/api/testfixtures/measure/TestMeasureComputerContext.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/test-fixtures/src/main/java/org/sonar/api/testfixtures/measure/TestMeasureComputerDefinition.java
+++ b/test-fixtures/src/main/java/org/sonar/api/testfixtures/measure/TestMeasureComputerDefinition.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/test-fixtures/src/main/java/org/sonar/api/testfixtures/measure/TestMeasureComputerDefinitionContext.java
+++ b/test-fixtures/src/main/java/org/sonar/api/testfixtures/measure/TestMeasureComputerDefinitionContext.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/test-fixtures/src/main/java/org/sonar/api/testfixtures/measure/TestSettings.java
+++ b/test-fixtures/src/main/java/org/sonar/api/testfixtures/measure/TestSettings.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/test-fixtures/src/main/java/org/sonar/api/testfixtures/posttask/PostProjectAnalysisTaskTester.java
+++ b/test-fixtures/src/main/java/org/sonar/api/testfixtures/posttask/PostProjectAnalysisTaskTester.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/test-fixtures/src/test/java/org/sonar/api/testfixtures/log/LogAndArgumentsTest.java
+++ b/test-fixtures/src/test/java/org/sonar/api/testfixtures/log/LogAndArgumentsTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/test-fixtures/src/test/java/org/sonar/api/testfixtures/log/LogTesterJUnit5Test.java
+++ b/test-fixtures/src/test/java/org/sonar/api/testfixtures/log/LogTesterJUnit5Test.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/test-fixtures/src/test/java/org/sonar/api/testfixtures/log/LogTesterTest.java
+++ b/test-fixtures/src/test/java/org/sonar/api/testfixtures/log/LogTesterTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/test-fixtures/src/test/java/org/sonar/api/testfixtures/measure/TestComponentTest.java
+++ b/test-fixtures/src/test/java/org/sonar/api/testfixtures/measure/TestComponentTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/test-fixtures/src/test/java/org/sonar/api/testfixtures/measure/TestIssueTest.java
+++ b/test-fixtures/src/test/java/org/sonar/api/testfixtures/measure/TestIssueTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/test-fixtures/src/test/java/org/sonar/api/testfixtures/measure/TestMeasureComputerContextTest.java
+++ b/test-fixtures/src/test/java/org/sonar/api/testfixtures/measure/TestMeasureComputerContextTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/test-fixtures/src/test/java/org/sonar/api/testfixtures/measure/TestMeasureComputerDefinitionTest.java
+++ b/test-fixtures/src/test/java/org/sonar/api/testfixtures/measure/TestMeasureComputerDefinitionTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/test-fixtures/src/test/java/org/sonar/api/testfixtures/measure/TestMeasureTest.java
+++ b/test-fixtures/src/test/java/org/sonar/api/testfixtures/measure/TestMeasureTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/test-fixtures/src/test/java/org/sonar/api/testfixtures/measure/TestSettingsTest.java
+++ b/test-fixtures/src/test/java/org/sonar/api/testfixtures/measure/TestSettingsTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/test-fixtures/src/test/java/org/sonar/api/testfixtures/posttask/PostProjectAnalysisTaskTesterTest.java
+++ b/test-fixtures/src/test/java/org/sonar/api/testfixtures/posttask/PostProjectAnalysisTaskTesterTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Plugin API
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or


### PR DESCRIPTION
[PLUGINAPI-167](https://sonarsource.atlassian.net/browse/PLUGINAPI-167)



[PLUGINAPI-167]: https://sonarsource.atlassian.net/browse/PLUGINAPI-167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ