### PR TITLE
PLUGINAPI-181 Update publishing info

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 group=org.sonarsource.api.plugin
 version=13.5-SNAPSHOT
-description=Plugin API for SonarQube, SonarCloud and SonarLint
+description=Plugin API for SonarQube Server, SonarQube Cloud and SonarQube for IDE
 org.gradle.jvmargs=-Xmx2048m

--- a/manifest/build.gradle
+++ b/manifest/build.gradle
@@ -17,6 +17,31 @@ publishing {
   publications {
     mavenJava(MavenPublication) {
       artifactId = 'sonar-plugin-manifest'
+      pom {
+        name = 'Sonar Plugin API - Manifest'
+        description = 'Sonar Plugin API - Manifest'
+        url = 'https://www.sonarsource.com/'
+        organization {
+          name = 'SonarSource'
+          url = 'https://www.sonarsource.com/'
+        }
+        licenses {
+          license {
+            name = 'GNU LGPL 3'
+            url = 'https://www.gnu.org/licenses/lgpl-3.0.txt'
+            distribution = 'repo'
+          }
+        }
+        scm {
+          url = 'https://github.com/SonarSource/sonar-plugin-api'
+        }
+        developers {
+          developer {
+            id = 'sonarsource-team'
+            name = 'SonarSource Team'
+          }
+        }
+      }
       artifact sourcesJar
       artifact javadocJar
     }

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -71,7 +71,7 @@ publishing {
       pom {
         name = 'Sonar Plugin API'
         description = project.description
-        url = 'https://www.sonarqube.org/'
+        url = 'https://www.sonarsource.com/'
         organization {
           name = 'SonarSource'
           url = 'https://www.sonarsource.com/'


### PR DESCRIPTION
The push to maven central during the release process failed with:
```
["Project name is missing","Project description is missing","Project URL is not defined","License information is missing","SCM URL is not defined","Developers information is missing"]
```
This PR adds the necessary info for the plugin manifest.