### PR TITLE
PLUGINAPI-190 Promote hidden to a first-class flag on PropertyDefinition

### DIFF
--- a/plugin-api/src/main/java/org/sonar/api/config/PropertyDefinition.java
+++ b/plugin-api/src/main/java/org/sonar/api/config/PropertyDefinition.java
@@ -136,6 +136,7 @@ public final class PropertyDefinition {
   private final String category;
   private final List<ConfigScope> configScopes;
   private final boolean global;
+  private final boolean hidden;
   private final boolean multiValues;
   private final String deprecatedKey;
   private final List<PropertyFieldDefinition> fields;
@@ -153,6 +154,7 @@ public final class PropertyDefinition {
     this.category = builder.category;
     this.subCategory = builder.subCategory;
     this.global = builder.global;
+    this.hidden = builder.hidden;
     this.type = builder.type;
     this.options = builder.options;
     this.multiValues = builder.multiValues;
@@ -189,10 +191,17 @@ public final class PropertyDefinition {
     if (annotation.module()) {
       configScopes.add(ConfigScope.MODULE);
     }
-    if (annotation.global()) {
+    // Translate the legacy invisibility idiom — @Property(global=false) with no
+    // scope — to the first-class hidden flag, so it survives the eventual removal
+    // of the global=false / empty-scope fallback in the server's settability check.
+    boolean isLegacyHiddenIdiom = !annotation.global() && configScopes.isEmpty();
+    if (annotation.global() || isLegacyHiddenIdiom) {
       builder.onConfigScopes(configScopes);
     } else {
       builder.onlyOnConfigScopes(configScopes);
+    }
+    if (isLegacyHiddenIdiom) {
+      builder.hidden();
     }
     return builder.build();
   }
@@ -342,6 +351,14 @@ public final class PropertyDefinition {
    */
   public boolean global() {
     return global;
+  }
+
+  /**
+   * Hidden properties are not discoverable, and typically don't appear in the UI.
+   * They can only be configured via the API.
+   */
+  public boolean hidden() {
+    return hidden;
   }
 
   public boolean multiValues() {
@@ -667,11 +684,7 @@ public final class PropertyDefinition {
       checkArgument(!isEmpty(key), "Key must be set");
       fixType(key, type);
       checkArgument(onConfigScopes.isEmpty() || onlyOnConfigScopes.isEmpty(), "Cannot use both forQualifiers and onlyForQualifiers");
-      checkArgument(!hidden || (onConfigScopes.isEmpty() && onlyOnConfigScopes.isEmpty()), "Cannot be hidden and defining qualifiers on which to display");
       checkArgument(!JSON.equals(type) || !multiValues, "Multivalues are not allowed to be defined for JSON-type property.");
-      if (hidden) {
-        global = false;
-      }
       if (!fields.isEmpty()) {
         type = PROPERTY_SET;
       }

--- a/plugin-api/src/main/java/org/sonar/api/config/PropertyDefinition.java
+++ b/plugin-api/src/main/java/org/sonar/api/config/PropertyDefinition.java
@@ -199,7 +199,7 @@ public final class PropertyDefinition {
       // else default state, visible and settable at instance level only
     } else {
       if (!configScopes.isEmpty()) {
-        // not visible but settable at scope only
+        // visible and settable at scope only
         builder.onlyOnConfigScopes(configScopes);
       } else {
         // legacy pattern for not visible but settable at instance level only

--- a/plugin-api/src/main/java/org/sonar/api/config/PropertyDefinition.java
+++ b/plugin-api/src/main/java/org/sonar/api/config/PropertyDefinition.java
@@ -191,17 +191,20 @@ public final class PropertyDefinition {
     if (annotation.module()) {
       configScopes.add(ConfigScope.MODULE);
     }
-    // Translate the legacy invisibility idiom — @Property(global=false) with no
-    // scope — to the first-class hidden flag, so it survives the eventual removal
-    // of the global=false / empty-scope fallback in the server's settability check.
-    boolean isLegacyHiddenIdiom = !annotation.global() && configScopes.isEmpty();
-    if (annotation.global() || isLegacyHiddenIdiom) {
-      builder.onConfigScopes(configScopes);
+    if (annotation.global()) {
+      if (!configScopes.isEmpty()) {
+        // visible and settable at instance and scope level
+        builder.onConfigScopes(configScopes);
+      }
+      // else default state, visible and settable at instance level only
     } else {
-      builder.onlyOnConfigScopes(configScopes);
-    }
-    if (isLegacyHiddenIdiom) {
-      builder.hidden();
+      if (!configScopes.isEmpty()) {
+        // not visible but settable at scope only
+        builder.onlyOnConfigScopes(configScopes);
+      } else {
+        // legacy pattern for not visible but settable at instance level only
+        builder.hidden();
+      }
     }
     return builder.build();
   }

--- a/plugin-api/src/test/java/org/sonar/api/config/PropertyDefinitionTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/config/PropertyDefinitionTest.java
@@ -96,6 +96,19 @@ public class PropertyDefinitionTest {
     assertThat(def.configScopes()).containsOnly(ConfigScope.PROJECT, ConfigScope.MODULE);
     assertThat(def.multiValues()).isTrue();
     assertThat(def.fields()).isEmpty();
+    assertThat(def.hidden()).isFalse();
+  }
+
+  @Test
+  public void should_translate_legacy_global_false_idiom_to_hidden() {
+    Properties props = AnnotationUtils.getAnnotation(LegacyHiddenIdiom.class, Properties.class);
+    Property prop = props.value()[0];
+
+    PropertyDefinition def = PropertyDefinition.create(prop);
+
+    assertThat(def.hidden()).isTrue();
+    assertThat(def.global()).isTrue();
+    assertThat(def.configScopes()).isEmpty();
   }
 
   @Test
@@ -108,7 +121,34 @@ public class PropertyDefinitionTest {
     assertThat(def.key()).isEqualTo("hello");
     assertThat(def.qualifiers()).isEmpty();
     assertThat(def.configScopes()).isEmpty();
+    assertThat(def.global()).isTrue();
+    assertThat(def.hidden()).isTrue();
+  }
+
+  @Test
+  public void should_create_hidden_property_with_on_config_scopes() {
+    PropertyDefinition def = PropertyDefinition.builder("hello")
+      .name("Hello")
+      .hidden()
+      .onConfigScopes(ConfigScope.PROJECT)
+      .build();
+
+    assertThat(def.hidden()).isTrue();
+    assertThat(def.global()).isTrue();
+    assertThat(def.configScopes()).containsExactly(ConfigScope.PROJECT);
+  }
+
+  @Test
+  public void should_create_hidden_property_with_only_on_config_scopes() {
+    PropertyDefinition def = PropertyDefinition.builder("hello")
+      .name("Hello")
+      .hidden()
+      .onlyOnConfigScopes(ConfigScope.PROJECT)
+      .build();
+
+    assertThat(def.hidden()).isTrue();
     assertThat(def.global()).isFalse();
+    assertThat(def.configScopes()).containsExactly(ConfigScope.PROJECT);
   }
 
   @Test
@@ -125,6 +165,7 @@ public class PropertyDefinitionTest {
     assertThat(def.description()).isEmpty();
     assertThat(def.type()).isEqualTo(PropertyType.STRING);
     assertThat(def.global()).isTrue();
+    assertThat(def.hidden()).isFalse();
     assertThat(def.qualifiers()).isEmpty();
     assertThat(def.configScopes()).isEmpty();
     assertThat(def.multiValues()).isFalse();
@@ -150,6 +191,7 @@ public class PropertyDefinitionTest {
     assertThat(def.configScopes()).isEmpty();
     assertThat(def.multiValues()).isFalse();
     assertThat(def.fields()).isEmpty();
+    assertThat(def.hidden()).isFalse();
   }
 
   @Test
@@ -321,22 +363,6 @@ public class PropertyDefinitionTest {
   }
 
   @Test
-  public void should_not_authorize_defining_on_qualifiers_and_hidden() {
-    Builder builder = PropertyDefinition.builder("foo").name("foo").onQualifiers(org.sonar.api.resources.Qualifiers.PROJECT).hidden();
-    assertThatThrownBy(builder::build)
-      .isInstanceOf(IllegalArgumentException.class)
-      .hasMessage("Cannot be hidden and defining qualifiers on which to display");
-  }
-
-  @Test
-  public void should_not_authorize_defining_ony_on_qualifiers_and_hidden() {
-    Builder builder = PropertyDefinition.builder("foo").name("foo").onlyOnQualifiers(org.sonar.api.resources.Qualifiers.PROJECT).hidden();
-    assertThatThrownBy(builder::build)
-      .isInstanceOf(IllegalArgumentException.class)
-      .hasMessage("Cannot be hidden and defining qualifiers on which to display");
-  }
-
-  @Test
   public void should_not_authorize_defining_on_qualifiers_and_only_on_qualifiers() {
     Builder builder = PropertyDefinition.builder("foo").name("foo").onQualifiers(org.sonar.api.resources.Qualifiers.MODULE)
       .onlyOnQualifiers(org.sonar.api.resources.Qualifiers.PROJECT);
@@ -468,6 +494,10 @@ public class PropertyDefinitionTest {
 
   @Properties(@Property(key = "hello", name = "Hello"))
   static class DefaultValues {
+  }
+
+  @Properties(@Property(key = "hello", name = "Hello", global = false))
+  static class LegacyHiddenIdiom {
   }
 
 }


### PR DESCRIPTION
<h3>WHY:</h3>
<p>The current plugin-api exposes <code>hidden</code>, <code>setScope</code>, and <code>setOnlyScope</code>. However, the effect of <code>hidden</code> is limited and only covers hiding the global variable when defined with scope. It is unusable with a scope. Internally, it is dropped, and its effect comes through the <code>global</code> flag, which disables showing the parameter at the instance level when no scope is defined.<br>
This is against the initial intention described in <a href="https://sonarsource.atlassian.net/browse/MMF-339">MMF-339</a>.</p>

<h3>WHAT:</h3>
<p>Add support for hiding properties independently from their scoped or global definition.<br>
Keep backward compatibility with existing definitions.</p>

<h3>HOW:</h3>
<p>Keep the <code>hidden</code> value as defined by the builder, and set <code>global</code> to represent whether the property is intended to be configured at the global level.<br>
<code>hidden</code> now has the meaning of hiding the property from the UI by not listing it.<br>
<code>global</code> now has the meaning of allowing get/edit of properties at the instance level.<br>
This allows simplifying the code by removing checks on <code>global</code> and scope that were carrying the <code>hidden</code> meaning before.</p>

<p>A backward-compatible translation is put in place for the legacy <code>@Property(global = false, scope=[])</code> idiom. It is auto-translated to <code>hidden = true, global = true, configScopes = []</code> which keep the behavior intact. The annotation itself is intentionally <strong>not</strong> extended with a <code>hidden</code> field, as it is already considered legacy and the builder should be used instead.</p>

<h2>Current behavior — truth table</h2>

<table>
<thead>
<tr>
<th colspan="3">Builder input</th>
<th rowspan="2">valid?</th>
<th colspan="2">Resulting state</th>
<th colspan="2">Effect (no component)</th>
<th colspan="2">Effect (comp = X)</th>
</tr>
<tr>
<th><code>.hidden()</code></th>
<th><code>.onConfigScopes(X)</code></th>
<th><code>.onlyOnConfigScopes(X)</code></th>
<th><code>global</code></th>
<th><code>configScopes</code></th>
<th>listed</th>
<th>settable</th>
<th>listed</th>
<th>settable</th>
</tr>
</thead>
<tbody>
<tr><td>–</td><td>–</td><td>–</td><td>✅</td><td>true</td><td>[]</td><td>✅</td><td>✅</td><td>❌</td><td>❌</td></tr>
<tr><td>✅</td><td>–</td><td>–</td><td>✅</td><td>false</td><td>[]</td><td>❌</td><td>✅ <em>(via <code>isGlobal</code> fallback)</em></td><td>❌</td><td>❌</td></tr>
<tr><td>–</td><td>✅</td><td>–</td><td>✅</td><td>true</td><td>[X]</td><td>✅</td><td>✅</td><td>✅</td><td>✅</td></tr>
<tr><td>–</td><td>–</td><td>✅</td><td>✅</td><td>false</td><td>[X]</td><td>❌</td><td>❌</td><td>✅</td><td>✅</td></tr>
<tr><td>✅</td><td>✅</td><td>–</td><td>❌</td><td>—</td><td>—</td><td>—</td><td>—</td><td>—</td><td>—</td></tr>
<tr><td>✅</td><td>–</td><td>✅</td><td>❌</td><td>—</td><td>—</td><td>—</td><td>—</td><td>—</td><td>—</td></tr>
<tr><td>–</td><td>✅</td><td>✅</td><td>❌</td><td>—</td><td>—</td><td>—</td><td>—</td><td>—</td><td>—</td></tr>
<tr><td>✅</td><td>✅</td><td>✅</td><td>❌</td><td>—</td><td>—</td><td>—</td><td>—</td><td>—</td><td>—</td></tr>
</tbody>
</table>

<h2>Proposed behavior — truth table</h2>

<table>
<thead>
<tr>
<th colspan="3">Builder input</th>
<th rowspan="2">valid?</th>
<th colspan="3">Resulting state</th>
<th colspan="2">Effect (no component)</th>
<th colspan="2">Effect (comp = X)</th>
</tr>
<tr>
<th><code>.hidden()</code></th>
<th><code>.onConfigScopes(X)</code></th>
<th><code>.onlyOnConfigScopes(X)</code></th>
<th><code>hidden</code></th>
<th><code>global</code></th>
<th><code>configScopes</code></th>
<th>listed</th>
<th>settable</th>
<th>listed</th>
<th>settable</th>
</tr>
</thead>
<tbody>
<tr><td>–</td><td>–</td><td>–</td><td>✅</td><td>false</td><td>true</td><td>[]</td><td>✅</td><td>✅</td><td>❌</td><td>❌</td></tr>
<tr><td>✅</td><td>–</td><td>–</td><td>✅</td><td><strong>true</strong></td><td><strong>true</strong></td><td>[]</td><td>❌ <em>(via <code>!hidden</code>)</em></td><td>✅</td><td>❌</td><td>❌</td></tr>
<tr><td>–</td><td>✅</td><td>–</td><td>✅</td><td>false</td><td>true</td><td>[X]</td><td>✅</td><td>✅</td><td>✅</td><td>✅</td></tr>
<tr><td>–</td><td>–</td><td>✅</td><td>✅</td><td>false</td><td>false</td><td>[X]</td><td>❌</td><td>❌</td><td>✅</td><td>✅</td></tr>
<tr><td>✅</td><td>✅</td><td>–</td><td>✅ <em>(newly allowed)</em></td><td>true</td><td>true</td><td>[X]</td><td>❌ <em>(via <code>!hidden</code>)</em></td><td>✅</td><td>❌ <em>(via <code>!hidden</code>)</em></td><td>✅</td></tr>
<tr><td>✅</td><td>–</td><td>✅</td><td>✅ <em>(newly allowed)</em></td><td>true</td><td>false</td><td>[X]</td><td>❌ <em>(via <code>!hidden</code>)</em></td><td>❌</td><td>❌ <em>(via <code>!hidden</code>)</em></td><td>✅</td></tr>
<tr><td>–</td><td>✅</td><td>✅</td><td>❌</td><td>—</td><td>—</td><td>—</td><td>—</td><td>—</td><td>—</td><td>—</td></tr>
<tr><td>✅</td><td>✅</td><td>✅</td><td>❌</td><td>—</td><td>—</td><td>—</td><td>—</td><td>—</td><td>—</td><td>—</td></tr>
</tbody>
</table>
