### PR TITLE
PLUGINAPI-194 Make PropertyDefinition.create public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 13.8
+* New public API `PropertyDefinition.create(Property)` to create properties from a `@Property` annotations
+
 ## 13.6
 * Deprecate `org.sonar.api.config.PropertyDefinitions`. Use `PropertyDefinition.builder(String)` to declare properties instead.
 * Add severity metric keys to `org.sonar.api.measures.CoreMetrics`:

--- a/plugin-api/src/main/java/org/sonar/api/config/PropertyDefinition.java
+++ b/plugin-api/src/main/java/org/sonar/api/config/PropertyDefinition.java
@@ -173,7 +173,12 @@ public final class PropertyDefinition {
     return new Builder(key);
   }
 
-  static PropertyDefinition create(Property annotation) {
+  /**
+   * Creates a {@link PropertyDefinition} from a {@link Property} annotation.
+   *
+   * @since 13.8
+   */
+  public static PropertyDefinition create(Property annotation) {
     Builder builder = PropertyDefinition.builder(annotation.key())
       .name(annotation.name())
       .defaultValue(annotation.defaultValue())


### PR DESCRIPTION
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->

# For SonarSourcers:
### Check before making the PR ready for review
<!--
  Please note that opening the PR will notify all the squad members.
    Please make sure you keep it in DRAFT and mark it ready, 
    when all the boxes are checked and you are only missing the review.
-->
- [x] Create a [JIRA](http://jira.sonarsource.com/browse/PLUGINAPI) ticket if the API is impacted
- [x] Prefix the commit message with the ticket number
- [x] Document the change in CHANGELOG.md
- [x] When adding a new API:
  - [x] Explain in the JavaDoc the purpose of the new API
  - [x] Add a `@since X.Y` in the JavaDoc
- [ ] When deprecating an API:
  - [ ] Annotate the deprecated element with `@Deprecated`
  - [ ] Add a `@deprecated since X.Y` in the JavaDoc
  - [ ] Document the replacement in the JavaDoc (if any)
- [ ] When dropping an API:
  - [ ] Make sure it respects the [deprecation policy](https://github.com/SonarSource/sonar-plugin-api/blob/master/docs/deprecation-policy.md)
  - [ ] Bump the major version (breaking change)
- [x] Make sure the tests adhere to the convention:
  - All test method names should use `snake_case`, for example: `test_validate_input`. It can also start with the `methodName`
- [x] Make sure checks are green: build passes, Quality Gate is green
- [ ] Merge after getting approval by at least one member of the guild
  - If no review is made within 3 days, gently ping the reviewers
  - The guild member reviewing the code can explicitly request someone else (typically another guild member representing another team) to check the impact on the specific product 
  - In some cases, the guild may deem it necessary that multiple or even all members approve a PR. This is more likely in complex changes or changes directly impacting all teams using the API.

