### PR TITLE
PLUGINAPI-201 Add new_ncloc (New Lines of Code) core metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 13.9
+## 13.10
 * Add the `NEW_NCLOC` metric to `org.sonar.api.measures.CoreMetrics`.
 
 ## 13.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 13.9
+* Add the `NEW_NCLOC` metric to `org.sonar.api.measures.CoreMetrics`.
+
 ## 13.8
 * New public API `PropertyDefinition.create(Property)` to create properties from a `@Property` annotations
 

--- a/plugin-api/src/main/java/org/sonar/api/measures/CoreMetrics.java
+++ b/plugin-api/src/main/java/org/sonar/api/measures/CoreMetrics.java
@@ -126,6 +126,21 @@ public final class CoreMetrics {
     .create();
 
   /**
+   * @since 13.9
+   */
+  public static final String NEW_NCLOC_KEY = "new_ncloc";
+  /**
+   * @since 13.9
+   */
+  public static final Metric<Integer> NEW_NCLOC = new Metric.Builder(NEW_NCLOC_KEY, "New Lines of Code", Metric.ValueType.INT)
+    .setDescription("Non commenting lines of code on new code")
+    .setDirection(Metric.DIRECTION_WORST)
+    .setQualitative(false)
+    .setDomain(DOMAIN_SIZE)
+    .setDeleteHistoricalData(true)
+    .create();
+
+  /**
    * @since 4.4
    */
   public static final String NCLOC_LANGUAGE_DISTRIBUTION_KEY = "ncloc_language_distribution";

--- a/plugin-api/src/main/java/org/sonar/api/measures/CoreMetrics.java
+++ b/plugin-api/src/main/java/org/sonar/api/measures/CoreMetrics.java
@@ -126,11 +126,11 @@ public final class CoreMetrics {
     .create();
 
   /**
-   * @since 13.9
+   * @since 13.10
    */
   public static final String NEW_NCLOC_KEY = "new_ncloc";
   /**
-   * @since 13.9
+   * @since 13.10
    */
   public static final Metric<Integer> NEW_NCLOC = new Metric.Builder(NEW_NCLOC_KEY, "New Lines of Code", Metric.ValueType.INT)
     .setDescription("Non commenting lines of code on new code")

--- a/plugin-api/src/test/java/org/sonar/api/resources/CoreMetricsTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/resources/CoreMetricsTest.java
@@ -29,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.sonar.api.measures.CoreMetrics.ACCEPTED_ISSUES;
 import static org.sonar.api.measures.CoreMetrics.FILES;
 import static org.sonar.api.measures.CoreMetrics.NCLOC;
+import static org.sonar.api.measures.CoreMetrics.NEW_NCLOC;
 import static org.sonar.api.measures.CoreMetrics.getMetric;
 import static org.sonar.api.measures.CoreMetrics.getMetrics;
 
@@ -38,7 +39,12 @@ public class CoreMetricsTest {
   public void read_metrics_from_class_reflection() {
     List<Metric> metrics = getMetrics();
     assertThat(metrics.size()).isGreaterThan(100);
-    assertThat(metrics).contains(NCLOC, FILES, ACCEPTED_ISSUES);
+    assertThat(metrics).contains(NCLOC, NEW_NCLOC, FILES, ACCEPTED_ISSUES);
+  }
+
+  @Test
+  public void new_ncloc_is_registered() {
+    assertThat(getMetric("new_ncloc")).isEqualTo(NEW_NCLOC);
   }
 
   @Test


### PR DESCRIPTION
## What

Adds a new core metric `new_ncloc` ("New Lines of Code") to `CoreMetrics` — the New Code period analog of `ncloc`.

## Why

There is currently no "lines of code on new code" metric. As a stand-in, the UI often pairs `new_lines` against `ncloc`, but they don't measure the same thing:

- `ncloc` counts **non-commenting lines of code** (a line the analyzer considers code), so `ncloc ≤ lines`.
- `new_lines` counts **all** changed lines in the New Code period — code, comments, and blanks.

The result is the paradox that a project can report **more `new_lines` than total `ncloc`**. `new_ncloc` (changed lines that are *also* code lines) is the honest new-code counterpart of `ncloc` and lets the product stop overloading `new_lines`.

## What's in this PR

Only the metric **definition** in `CoreMetrics`. This is the lowest-level, most-blocking change: the Compute Engine computation, Elasticsearch indexing, and web app all reference `CoreMetrics.NEW_NCLOC_KEY`, so nothing downstream compiles until this is released.

```java
public static final String NEW_NCLOC_KEY = "new_ncloc";
public static final Metric<Integer> NEW_NCLOC = new Metric.Builder(NEW_NCLOC_KEY, "New Lines of Code", Metric.ValueType.INT)
  .setDescription("Non commenting lines of code on new code")
  .setDirection(Metric.DIRECTION_WORST)
  .setQualitative(false)
  .setDomain(DOMAIN_SIZE)
  .setDeleteHistoricalData(true)
  .create();
```

The attributes mirror `NEW_LINES` (and `NCLOC`): `INT`, `DIRECTION_WORST`, non-qualitative, `DOMAIN_SIZE`, `deleteHistoricalData(true)`. As a size measure it intentionally has **no** `bestValue`/`optimizedBestValue` (consistent with `ncloc`/`new_lines`; setting `optimizedBestValue` would drop the measure on files with 0 new code lines, reintroducing the absent-vs-0 inconsistency this metric is meant to remove).

No DB migration is needed: metrics are auto-registered from `CoreMetrics` by reflection at server startup (`RegisterMetrics`).

## Sequencing (this PR blocks the rest)

1. **This PR** → merge, then release `sonar-plugin-api` and bump `pluginApiVersion` in the consumers.
2. Compute `new_ncloc` in the Compute Engine — `sonar-enterprise` and `sonarcloud-cleancode` (`NewSizeMeasuresStep`: `ncloc_data ∩ changed lines`).
3. Index it for project search — `ProjectMeasuresIndexerIterator` in `sonar-enterprise` and `sonarcloud-core`.
4. Surface it in the web app — `sonarcloud-webapp` (`MetricKey`, l10n, Measures → Size domain).

Out of scope here and tracked separately: application/portfolio aggregation, ES range facet + project-search filtering, and the frontend rework that replaces `new_lines` where it stands in as the `ncloc` counterpart.

## Validation

`CoreMetricsTest` passes; built locally against a JDK 11 toolchain.

Ticket: SONAR-26742

🤖 Generated with [Claude Code](https://claude.com/claude-code)