### PR TITLE
PLUGINAPI-196 Change Code Owners and Slack notification

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-* @sonarsource/quality-processing-squad
+
+* @sonarsource/code-quality-ci-experience-squad

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,6 @@ jobs:
     with:
       publishToBinaries: true
       mavenCentralSync: true
-      slackChannel: ops-analysis-experience
+      slackChannel: ops-ci-experience
       publishJavadoc: true
       publicRelease: true


### PR DESCRIPTION
----
## Summary by Gitar

- **Configuration changes:**
  - Updated `.github/CODEOWNERS` to assign ownership to `@sonarsource/code-quality-ci-experience-squad`.
  - Changed `slackChannel` to `ops-ci-experience` in `.github/workflows/release.yml`.

<sub>This will update automatically on new commits.</sub>