### PR TITLE
PLUGINAPI-199 Upgrade logback-classic to version 1.5.38

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -8,7 +8,7 @@ include 'shared'
 dependencyResolutionManagement {
   versionCatalogs {
     libs {
-      version('slf4j', '1.7.30')
+      version('slf4j', '2.0.17')
       library('commons-io', 'commons-io:commons-io:2.16.1')
       library('commons-lang3', 'org.apache.commons:commons-lang3:3.20.0')
       library('commons-text', 'org.apache.commons:commons-text:1.12.0')
@@ -21,7 +21,7 @@ dependencyResolutionManagement {
       library('jupiter-engine', 'org.junit.jupiter:junit-jupiter-engine:5.10.3')
       library('jupiter-vintage-engine', 'org.junit.vintage:junit-vintage-engine:5.10.3')
       library('slf4j', 'org.slf4j', 'slf4j-api').versionRef('slf4j')
-      library('logback-classic', 'ch.qos.logback:logback-classic:1.2.13')
+      library('logback-classic', 'ch.qos.logback:logback-classic:1.5.38')
       library('assertj', 'org.assertj:assertj-core:3.26.0')
       library('mockito', 'org.mockito:mockito-core:5.12.0')
       library('junit-dataprovider', 'com.tngtech.java:junit-dataprovider:1.13.1')


### PR DESCRIPTION
----
## Summary by Gitar

- **Dependency updates:**
  - Upgraded `logback-classic` from `1.2.13` to `1.5.38` in `settings.gradle`.
  - Upgraded `slf4j` version reference from `1.7.30` to `2.0.17` to ensure compatibility.

<sub>This will update automatically on new commits.</sub>