### PR TITLE
PLUGINAPI-203 Add supportsScopedOrganizationTokens flag to WebService

### DIFF
--- a/plugin-api/src/main/java/org/sonar/api/server/ws/WebService.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/ws/WebService.java
@@ -251,6 +251,7 @@ public interface WebService extends Definable<WebService.Context> {
     private String deprecatedSince;
     private boolean post = false;
     private boolean isInternal = false;
+    private boolean supportsScopedOrganizationTokens = false;
     private RequestHandler handler;
     private Map<String, NewParam> newParams = new HashMap<>();
     private URL responseExample = null;
@@ -306,6 +307,18 @@ public interface WebService extends Definable<WebService.Context> {
      */
     public NewAction setInternal(boolean b) {
       this.isInternal = b;
+      return this;
+    }
+
+    /**
+     * Indicates that the action can be authenticated using a SonarQube Cloud scoped
+     * organization token, in addition to any other supported authentication mechanism.
+     * This is only relevant to SonarQube Cloud. By default an action does not support it.
+     *
+     * @since 13.9
+     */
+    public NewAction setSupportsScopedOrganizationTokens(boolean b) {
+      this.supportsScopedOrganizationTokens = b;
       return this;
     }
 
@@ -511,6 +524,7 @@ public interface WebService extends Definable<WebService.Context> {
     private final String deprecatedSince;
     private final boolean post;
     private final boolean isInternal;
+    private final boolean supportsScopedOrganizationTokens;
     private final RequestHandler handler;
     private final Map<String, Param> params;
     private final URL responseExample;
@@ -526,6 +540,7 @@ public interface WebService extends Definable<WebService.Context> {
       this.deprecatedSince = newAction.deprecatedSince;
       this.post = newAction.post;
       this.isInternal = newAction.isInternal;
+      this.supportsScopedOrganizationTokens = newAction.supportsScopedOrganizationTokens;
       this.responseExample = newAction.responseExample;
       this.handler = newAction.handler;
       this.changelog = newAction.changelog;
@@ -600,6 +615,14 @@ public interface WebService extends Definable<WebService.Context> {
      */
     public boolean isInternal() {
       return isInternal;
+    }
+
+    /**
+     * @see NewAction#setSupportsScopedOrganizationTokens(boolean)
+     * @since 13.9
+     */
+    public boolean isSupportsScopedOrganizationTokens() {
+      return supportsScopedOrganizationTokens;
     }
 
     public RequestHandler handler() {

--- a/plugin-api/src/test/java/org/sonar/api/server/ws/WebServiceTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/server/ws/WebServiceTest.java
@@ -79,6 +79,7 @@ public class WebServiceTest {
     assertThat(showAction.since()).isEqualTo("4.2");
     assertThat(showAction.isPost()).isFalse();
     assertThat(showAction.isInternal()).isFalse();
+    assertThat(showAction.isSupportsScopedOrganizationTokens()).isFalse();
     assertThat(showAction.path()).isEqualTo("api/metric/show");
     WebService.Action createAction = controller.action("create");
     assertThat(createAction).isNotNull();
@@ -89,6 +90,7 @@ public class WebServiceTest {
     assertThat(createAction.since()).isEqualTo("4.1");
     assertThat(createAction.isPost()).isTrue();
     assertThat(createAction.isInternal()).isTrue();
+    assertThat(createAction.isSupportsScopedOrganizationTokens()).isTrue();
     assertThat(createAction.changelog()).extracting(Change::getVersion, Change::getDescription).containsOnly(
       tuple("6.4", "Last event"), tuple("6.0", "Old event"), tuple("4.5.6", "Very old event"));
   }
@@ -539,6 +541,7 @@ public class WebServiceTest {
         .setDeprecatedSince("5.3")
         .setPost(true)
         .setInternal(true)
+        .setSupportsScopedOrganizationTokens(true)
         .setResponseExample(getClass().getResource("WebServiceTest/response-example.txt"))
         .setChangelog(
           new Change("6.4", "Last event"),


### PR DESCRIPTION
## Summary
- Adds a new per-action boolean flag `supportsScopedOrganizationTokens` to `WebService.NewAction`/`Action` (`org.sonar.api.server.ws`), following the existing `internal`/`post` pattern (mutable field + fluent setter on `NewAction`, immutable field + getter on `Action`).
- This flag lets SonarQube Cloud declare, in its Web API documentation, which actions accept authentication via a Scoped Organization Token (SOT). It's infrastructure only — no WS action is annotated with it yet.
- Extends `WebServiceTest`'s `MetricWs` fixture to cover both the default (`false`) and an explicit `true` override.

Tracked in PLUGINAPI-203. SonarQube Cloud's `GET api/webservices/list` serialization (SC-53832) depends on this being released, since `sonarcloud-core` pins `sonar-plugin-api` at a released version rather than a local build.

## Test plan
- [x] `./gradlew :plugin-api:test --tests "org.sonar.api.server.ws.WebServiceTest"` passes