### PR TITLE
PLUGINAPI-208/209 Add MQR severity and issue-count metrics to CoreMetrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 13.11
 * Add MQR mode metrics for worst issue severity for overall code to `org.sonar.api.measures.CoreMetrics`:
   * `RELIABILITY_ISSUE_SEVERITY`, `SECURITY_ISSUE_SEVERITY`, `MAINTAINABILITY_ISSUE_SEVERITY`
+* Add the MQR issues count flat metrics to `org.sonar.api.measures.CoreMetrics`:
+  * `SOFTWARE_QUALITY_MAINTAINABILITY_ISSUES`, `SOFTWARE_QUALITY_RELIABILITY_ISSUES`, `SOFTWARE_QUALITY_SECURITY_ISSUES`
+  * `NEW_SOFTWARE_QUALITY_MAINTAINABILITY_ISSUES`, `NEW_SOFTWARE_QUALITY_RELIABILITY_ISSUES`, `NEW_SOFTWARE_QUALITY_SECURITY_ISSUES`
 
 ## 13.10
 * Add the `NEW_NCLOC` metric to `org.sonar.api.measures.CoreMetrics`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 13.11
+* Add MQR mode metrics for worst issue severity for overall code to `org.sonar.api.measures.CoreMetrics`:
+  * `RELIABILITY_ISSUE_SEVERITY`, `SECURITY_ISSUE_SEVERITY`, `MAINTAINABILITY_ISSUE_SEVERITY`
+
 ## 13.10
 * Add the `NEW_NCLOC` metric to `org.sonar.api.measures.CoreMetrics`.
 

--- a/plugin-api/src/main/java/org/sonar/api/measures/CoreMetrics.java
+++ b/plugin-api/src/main/java/org/sonar/api/measures/CoreMetrics.java
@@ -1063,6 +1063,24 @@ public final class CoreMetrics {
     .create();
 
   /**
+   * @since 13.11
+   */
+  public static final String RELIABILITY_ISSUE_SEVERITY_KEY = "reliability_issue_severity";
+
+  /**
+   * @since 13.11
+   */
+  public static final Metric<Integer> RELIABILITY_ISSUE_SEVERITY = new Metric.Builder(RELIABILITY_ISSUE_SEVERITY_KEY,
+    "Reliability Issue Severity on Overall Code", Metric.ValueType.INT)
+    .setDescription("Worst severity of reliability issues")
+    .setDomain(DOMAIN_RELIABILITY)
+    .setDirection(Metric.DIRECTION_WORST)
+    .setOptimizedBestValue(true)
+    .setBestValue((double) SeverityValues.NO_ISSUES)
+    .setWorstValue((double) SeverityValues.BLOCKER)
+    .create();
+
+  /**
    * @since 13.6
    */
   public static final String NEW_RELIABILITY_ISSUE_SEVERITY_KEY = "new_reliability_issue_severity";
@@ -1082,6 +1100,24 @@ public final class CoreMetrics {
     .create();
 
   /**
+   * @since 13.11
+   */
+  public static final String SECURITY_ISSUE_SEVERITY_KEY = "security_issue_severity";
+
+  /**
+   * @since 13.11
+   */
+  public static final Metric<Integer> SECURITY_ISSUE_SEVERITY = new Metric.Builder(SECURITY_ISSUE_SEVERITY_KEY,
+    "Security Issue Severity on Overall Code", Metric.ValueType.INT)
+    .setDescription("Worst severity of security issues")
+    .setDomain(DOMAIN_SECURITY)
+    .setDirection(Metric.DIRECTION_WORST)
+    .setOptimizedBestValue(true)
+    .setBestValue((double) SeverityValues.NO_ISSUES)
+    .setWorstValue((double) SeverityValues.BLOCKER)
+    .create();
+
+  /**
    * @since 13.6
    */
   public static final String NEW_SECURITY_ISSUE_SEVERITY_KEY = "new_security_issue_severity";
@@ -1095,6 +1131,24 @@ public final class CoreMetrics {
     .setDomain(DOMAIN_SECURITY)
     .setDirection(Metric.DIRECTION_WORST)
     .setDeleteHistoricalData(true)
+    .setOptimizedBestValue(true)
+    .setBestValue((double) SeverityValues.NO_ISSUES)
+    .setWorstValue((double) SeverityValues.BLOCKER)
+    .create();
+
+  /**
+   * @since 13.11
+   */
+  public static final String MAINTAINABILITY_ISSUE_SEVERITY_KEY = "maintainability_issue_severity";
+
+  /**
+   * @since 13.11
+   */
+  public static final Metric<Integer> MAINTAINABILITY_ISSUE_SEVERITY = new Metric.Builder(MAINTAINABILITY_ISSUE_SEVERITY_KEY,
+    "Maintainability Issue Severity on Overall Code", Metric.ValueType.INT)
+    .setDescription("Worst severity of maintainability issues")
+    .setDomain(DOMAIN_MAINTAINABILITY)
+    .setDirection(Metric.DIRECTION_WORST)
     .setOptimizedBestValue(true)
     .setBestValue((double) SeverityValues.NO_ISSUES)
     .setWorstValue((double) SeverityValues.BLOCKER)

--- a/plugin-api/src/main/java/org/sonar/api/measures/CoreMetrics.java
+++ b/plugin-api/src/main/java/org/sonar/api/measures/CoreMetrics.java
@@ -1641,6 +1641,43 @@ public final class CoreMetrics {
       .setOptimizedBestValue(true)
       .create();
 
+  /**
+   * @since 13.11
+   */
+  public static final String SOFTWARE_QUALITY_MAINTAINABILITY_ISSUES_KEY = "software_quality_maintainability_issues";
+
+  /**
+   * @since 13.11
+   */
+  public static final Metric<Integer> SOFTWARE_QUALITY_MAINTAINABILITY_ISSUES =
+    new Metric.Builder(SOFTWARE_QUALITY_MAINTAINABILITY_ISSUES_KEY, "Maintainability Issues", Metric.ValueType.INT)
+      .setDescription("Number of open issues impacting the Maintainability software quality")
+      .setDirection(Metric.DIRECTION_WORST)
+      .setQualitative(false)
+      .setDomain(DOMAIN_MAINTAINABILITY)
+      .setBestValue(0.0)
+      .setOptimizedBestValue(true)
+      .create();
+
+  /**
+   * @since 13.11
+   */
+  public static final String NEW_SOFTWARE_QUALITY_MAINTAINABILITY_ISSUES_KEY = "new_software_quality_maintainability_issues";
+
+  /**
+   * @since 13.11
+   */
+  public static final Metric<Integer> NEW_SOFTWARE_QUALITY_MAINTAINABILITY_ISSUES =
+    new Metric.Builder(NEW_SOFTWARE_QUALITY_MAINTAINABILITY_ISSUES_KEY, "New Maintainability Issues", Metric.ValueType.INT)
+      .setDescription("Number of open issues impacting the Maintainability software quality on new code")
+      .setDirection(Metric.DIRECTION_WORST)
+      .setQualitative(true)
+      .setDomain(DOMAIN_MAINTAINABILITY)
+      .setBestValue(0.0)
+      .setOptimizedBestValue(true)
+      .setDeleteHistoricalData(true)
+      .create();
+
   // --------------------------------------------------------------------------------------------------------------------
   //
   // RELIABILITY CHARACTERISTIC
@@ -1720,6 +1757,43 @@ public final class CoreMetrics {
     .setWorstValue(5.0)
     .create();
 
+  /**
+   * @since 13.11
+   */
+  public static final String SOFTWARE_QUALITY_RELIABILITY_ISSUES_KEY = "software_quality_reliability_issues";
+
+  /**
+   * @since 13.11
+   */
+  public static final Metric<Integer> SOFTWARE_QUALITY_RELIABILITY_ISSUES =
+    new Metric.Builder(SOFTWARE_QUALITY_RELIABILITY_ISSUES_KEY, "Reliability Issues", Metric.ValueType.INT)
+      .setDescription("Number of open issues impacting the Reliability software quality")
+      .setDirection(Metric.DIRECTION_WORST)
+      .setQualitative(false)
+      .setDomain(DOMAIN_RELIABILITY)
+      .setBestValue(0.0)
+      .setOptimizedBestValue(true)
+      .create();
+
+  /**
+   * @since 13.11
+   */
+  public static final String NEW_SOFTWARE_QUALITY_RELIABILITY_ISSUES_KEY = "new_software_quality_reliability_issues";
+
+  /**
+   * @since 13.11
+   */
+  public static final Metric<Integer> NEW_SOFTWARE_QUALITY_RELIABILITY_ISSUES =
+    new Metric.Builder(NEW_SOFTWARE_QUALITY_RELIABILITY_ISSUES_KEY, "New Reliability Issues", Metric.ValueType.INT)
+      .setDescription("Number of open issues impacting the Reliability software quality on new code")
+      .setDirection(Metric.DIRECTION_WORST)
+      .setQualitative(true)
+      .setDomain(DOMAIN_RELIABILITY)
+      .setBestValue(0.0)
+      .setOptimizedBestValue(true)
+      .setDeleteHistoricalData(true)
+      .create();
+
   // --------------------------------------------------------------------------------------------------------------------
   //
   // SECURITY CHARACTERISTIC
@@ -1797,6 +1871,43 @@ public final class CoreMetrics {
     .setBestValue(1.0)
     .setWorstValue(5.0)
     .create();
+
+  /**
+   * @since 13.11
+   */
+  public static final String SOFTWARE_QUALITY_SECURITY_ISSUES_KEY = "software_quality_security_issues";
+
+  /**
+   * @since 13.11
+   */
+  public static final Metric<Integer> SOFTWARE_QUALITY_SECURITY_ISSUES =
+    new Metric.Builder(SOFTWARE_QUALITY_SECURITY_ISSUES_KEY, "Security Issues", Metric.ValueType.INT)
+      .setDescription("Number of open issues impacting the Security software quality")
+      .setDirection(Metric.DIRECTION_WORST)
+      .setQualitative(false)
+      .setDomain(DOMAIN_SECURITY)
+      .setBestValue(0.0)
+      .setOptimizedBestValue(true)
+      .create();
+
+  /**
+   * @since 13.11
+   */
+  public static final String NEW_SOFTWARE_QUALITY_SECURITY_ISSUES_KEY = "new_software_quality_security_issues";
+
+  /**
+   * @since 13.11
+   */
+  public static final Metric<Integer> NEW_SOFTWARE_QUALITY_SECURITY_ISSUES =
+    new Metric.Builder(NEW_SOFTWARE_QUALITY_SECURITY_ISSUES_KEY, "New Security Issues", Metric.ValueType.INT)
+      .setDescription("Number of open issues impacting the Security software quality on new code")
+      .setDirection(Metric.DIRECTION_WORST)
+      .setQualitative(true)
+      .setDomain(DOMAIN_SECURITY)
+      .setBestValue(0.0)
+      .setOptimizedBestValue(true)
+      .setDeleteHistoricalData(true)
+      .create();
 
   // --------------------------------------------------------------------------------------------------------------------
   //


### PR DESCRIPTION
## What

Two related additions to `org.sonar.api.measures.CoreMetrics`, both part of the [SC-53446](https://sonarsource.atlassian.net/browse/SC-53446) (Deprecate Standard metrics and promote MQR-related metrics) effort:

#### PLUGINAPI-208 - severity metrics for overall code (MQR mode)
`CoreMetrics`  had already declared the new-code-period severity metrics (`new_reliability_issue_severity`, `new_security_issue_severity`, `new_maintainability_issue_severity`). This adds the overall-code equivalents.

#### PLUGINAPI-209 -  flat issue count metrics
SQC needs flat count metrics equivalent to SQS's `software_quality_*_issues` so that:
- Deprecated standard metrics (`bugs`, `new_bugs`, `vulnerabilities`, `new_vulnerabilities`, `code_smells`, `new_code_smells`) can be replaced on the measures page and in project badges
- The new metrics can be used as Quality Gate conditions
- SQC and SQS implementations stay aligned, reducing divergence

These flat count metrics currently exist in a dedicated class in SQS, `SoftwareQualitiesMetrics` (not in `CoreMetrics`), and SQC does not compute them. Moving them to `CoreMetrics` follows the established convention and lets both products share the same declaration.

## What's in this PR

New 9 metrics **definitions** in `CoreMetrics`:
- 3 severity metrics (overall code): `RELIABILITY_ISSUE_SEVERITY`, `SECURITY_ISSUE_SEVERITY`, `MAINTAINABILITY_ISSUE_SEVERITY`
- 6 issue-count metrics: `SOFTWARE_QUALITY_{MAINTAINABILITY,RELIABILITY,SECURITY}_ISSUES` and their `NEW_*` variants

This is the lowest-level, most-blocking change: the **report processor** analysis and **sonarcloud-core** measures formulas need these metrics to exist before they can compute them.

The issue-count metrics mirror SQS's `SoftwareQualitiesMetrics` class exactly (value type, direction, best value, qualitative flags). The severity metrics mirror the existing `NEW_*_ISSUE_SEVERITY` metrics' shape (value type, direction, best/worst value on the 0-25 `SeverityValues` scale).

Metrics are auto-registered from `CoreMetrics` by reflection at server startup (`RegisterMetrics`).

## Sequencing (this PR blocks the rest)

1. This PR — declare metrics in `CoreMetrics` (plugin-api)
2. Report processor — compute the metrics during analysis.
3. sonarcloud-core — measures formulas to aggregate values for new/overall code
4. SQC frontend — measures page + project badges switch from deprecated standard metrics to these
5. Quality Gate — allow these as conditions

## Notes

- Issue-count metrics: `setQualitative(false)` on the 3 overall-code metrics, `true` on the 3 `new_*` variants — intentionally mirrors SQS's `SoftwareQualitiesMetrics` as-is, not an inconsistency.
- `@since 13.10` matches the current `gradle.properties` version (`13.10-SNAPSHOT`) and the `CHANGELOG.md` entries added under `## 13.10`.

## Validation

- Local compile verified
- `CHANGELOG.md` updated under `## 13.10`, two entries (severity metrics, issue-count metrics)

[SC-53446]: https://sonarsource.atlassian.net/browse/SC-53446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ