### PR TITLE
PLUGINAPI-175 Upgrade logback and slf4j versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 14.0
+* Upgrade the provided `slf4j-api` from 1.7.30 to 2.0.18.
+
 ## 13.11
 * Add MQR mode metrics for worst issue severity for overall code to `org.sonar.api.measures.CoreMetrics`:
   * `RELIABILITY_ISSUE_SEVERITY`, `SECURITY_ISSUE_SEVERITY`, `MAINTAINABILITY_ISSUE_SEVERITY`

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 group=org.sonarsource.api.plugin
-version=13.12-SNAPSHOT
+version=14.0-SNAPSHOT
 description=Plugin API for SonarQube Server, SonarQube Cloud and SonarQube for IDE
 org.gradle.jvmargs=-Xmx2048m

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-slf4j = "1.7.30"
+slf4j = "2.0.18"
 junit = "5.14.4"
 # org.junit.platform artifacts (e.g. junit-platform-launcher) have their own major version:
 # Platform 1.x.y is released together with Jupiter 5.x.y (same minor/patch).
@@ -24,7 +24,7 @@ jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.re
 jupiter-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine", version.ref = "junit" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit-platform" }
 slf4j = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
-logback-classic = { module = "ch.qos.logback:logback-classic", version = "1.2.13" }
+logback-classic = { module = "ch.qos.logback:logback-classic", version = "1.6.3" }
 assertj = { module = "org.assertj:assertj-core", version = "3.27.7" }
 mockito = { module = "org.mockito:mockito-core", version = "5.23.0" }
 junit-dataprovider = { module = "com.tngtech.java:junit-dataprovider", version = "1.13.1" }


### PR DESCRIPTION
## Summary
* Upgrade `slf4j-api` from 1.7.30 to 2.0.18 (latest 2.x) and `logback-classic` from 1.2.13 to 1.6.3 (latest release). Logback-classic 1.2.x is EOL and no longer receives security updates.
* Logback 1.3+ requires slf4j 2.x, and slf4j 2.x is not binary compatible with slf4j 1.x, so this is a breaking change for consumers who bundle/expose their own slf4j 1.x dependency or bindings.
* Bump the plugin API version to `14.0-SNAPSHOT` to reflect the major/breaking nature of this change (a previous attempt at this upgrade, #262, only bumped logback without slf4j and was reverted in PLUGINAPI-174).

Jira: https://sonarsource.atlassian.net/browse/PLUGINAPI-175

## Test plan
- [x] `./gradlew build` passes (compiles and all existing tests pass) with the new versions
- [x] Verified via `./gradlew :plugin-api:dependencies` that only slf4j 2.0.18 is resolved on the runtime classpath (no stray 1.x version)
- [ ] Downstream products (SonarQube Server/Cloud/IDE) should be tested against this API version before it is consumed, since this is a breaking change

🤖 Generated with [Claude Code](https://claude.com/claude-code)