### PR TITLE
PLUGINAPI-219 Update target Java version to 17 and upgrade JUnit to 6.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 14.0
 * Upgrade the provided `slf4j-api` from 1.7.30 to 2.0.18.
+* Raise the minimum required Java version from 11 to 17.
+* Upgrade JUnit from 5.x to 6.x for consumers using the test-fixtures module.
 
 ## 13.11
 * Add MQR mode metrics for worst issue severity for overall code to `org.sonar.api.measures.CoreMetrics`:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Java API to develop plugins for SonarQube (Server, Cloud) and SonarQube for IDE.
 This component was extracted out of SonarQube and has been released independently since v9.5.
 
-The API is built with JDK 11.
+The API is built with JDK 17.
 
 ## Developing plugins
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,9 +89,6 @@ subprojects {
   tasks.withType<Javadoc> {
     options.encoding = "UTF-8"
     (options as StandardJavadocDocletOptions).addStringOption("Xdoclint:none", "-quiet")
-    doFirst {
-      (options as StandardJavadocDocletOptions).addBooleanOption("-no-module-directories", true)
-    }
   }
 
   val mainSourceSet = the<SourceSetContainer>()["main"]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ subprojects {
 
   configure<JavaPluginExtension> {
     toolchain {
-      languageVersion.set(JavaLanguageVersion.of(11))
+      languageVersion.set(JavaLanguageVersion.of(17))
     }
   }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,6 @@
 [versions]
 slf4j = "2.0.18"
-junit = "5.14.4"
-# org.junit.platform artifacts (e.g. junit-platform-launcher) have their own major version:
-# Platform 1.x.y is released together with Jupiter 5.x.y (same minor/patch).
-junit-platform = "1.14.4"
+junit = "6.1.3"
 jacoco = "0.8.15"
 license-plugin = "0.16.1"
 shadow-plugin = "9.6.1"
@@ -22,7 +19,7 @@ junit4 = { module = "junit:junit", version = "4.13.2" }
 junit5 = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }
 jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
 jupiter-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine", version.ref = "junit" }
-junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit-platform" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit" }
 slf4j = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version = "1.6.3" }
 assertj = { module = "org.assertj:assertj-core", version = "3.27.7" }


### PR DESCRIPTION
## Summary
* Raise the Gradle toolchain/target Java version from 11 to 17 (`build.gradle.kts`).
* Upgrade JUnit from 5.14.4 to 6.1.3 (latest). JUnit 6 unifies the jupiter/platform/vintage module versions under a single number, so the separate `junit-platform` catalog entry is dropped in favor of reusing `junit`.
* Update the README to reflect the new build JDK.

Stacked on top of #316 (PLUGINAPI-175) — this PR targets that branch rather than `master`.

Jira: https://sonarsource.atlassian.net/browse/PLUGINAPI-219

## Test plan
- [x] `./gradlew clean build` passes on JDK 17 (compiles and all existing tests pass) with JUnit 6.1.3
- [x] Verified via `./gradlew :plugin-api:dependencies` that all JUnit modules (jupiter, platform, vintage) resolve consistently to 6.1.3 with no conflicts
- [ ] Downstream products should be tested against this API version before it is consumed, since raising the minimum JDK to 17 is a breaking change

🤖 Generated with [Claude Code](https://claude.com/claude-code)