### PR TITLE
PLUGINAPI-221 Rename code-quality teams to code-orchestration in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-* @sonarsource/code-quality-ci-experience-squad
+* @sonarsource/code-orchestration-ci-experience-squad


### PR DESCRIPTION
## Summary
- We replaced code-quality by code-orchestration for the teams analysis-processing, autoscan, and ci-experience.

## Test plan
- [x] Verified `code-orchestration-ci-experience-squad` exists as a GitHub team in the SonarSource org.