### PR TITLE
PLUGINAPI-226 Remove deprecation on IssueStatus.CONFIRMED

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 14.1
+* Remove deprecation on `org.sonar.api.issue.IssueStatus.CONFIRMED`.
+
 ## 14.0
 * Upgrade the provided `slf4j-api` from 1.7.30 to 2.0.18.
 * Raise the minimum required Java version from 11 to 17.

--- a/plugin-api/src/main/java/org/sonar/api/issue/IssueStatus.java
+++ b/plugin-api/src/main/java/org/sonar/api/issue/IssueStatus.java
@@ -32,10 +32,6 @@ public enum IssueStatus {
 
   OPEN,
 
-  @Deprecated(since = "10.4")
-  /**
-   * @deprecated use {@link IssueStatus#ACCEPTED} instead
-   */
   CONFIRMED,
   FALSE_POSITIVE,
   ACCEPTED,


### PR DESCRIPTION
## Summary
- PLUGINAPI-226 / SC-55707: Remove deprecation on `org.sonar.api.issue.IssueStatus.CONFIRMED`.

## Test plan
- [ ] CI build passes